### PR TITLE
add lecture 01 teaching draft

### DIFF
--- a/slides/README.md
+++ b/slides/README.md
@@ -5,10 +5,11 @@ notebook for each lecture. The [sample deck](example/index.html) demonstrates
 the layouts using a short tokenization lesson. It is a format sample, not the
 complete first lecture.
 
-[Lecture 01](lecture-01/index.html) now has its own folder, starting with the
-sample's tokenization content. Continue developing that deck for the first
-class. Its notebook is [lecture-01-exercise.ipynb](lecture-01/lecture-01-exercise.ipynb),
-and course paper PDFs are kept in [papers/](../papers/README.md).
+[Lecture 01](lecture-01/index.html) combines course introduction, local-model
+experiments, Unicode, and byte BPE for three 45-minute periods. Its
+[teaching plan](lecture-01/teaching-plan.md) maps the timing and sources; its
+[notebook](lecture-01/lecture-01-exercise.ipynb) contains the Ollama demonstrations
+and matching exercises. Course paper PDFs are kept in [papers/](../papers/README.md).
 
 ## Teaching from a classroom browser
 
@@ -47,6 +48,12 @@ Open `http://127.0.0.1:8000/slides/example/` (or the lecture's folder) and click
 `workspace/slides/example/practice.ipynb`. Later clicks reopen that copy and
 preserve saved answers. The lecture's `assets/` folder is copied the first time
 it is needed; existing personal files are not replaced by new course releases.
+
+To receive an updated handout, rename your existing personal notebook in
+JupyterLab, then click **Notebook** again. Keep the renamed file for your earlier
+answers. Lecture 01's text-model demonstrations require a separate Ollama
+installation and model; preparation is explained inside the notebook. Its core
+tokenization exercises run offline without Ollama.
 
 The launcher checks registered local Jupyter servers. It reuses one when its
 root directory includes this notebook, JupyterLab is available, and its
@@ -130,6 +137,7 @@ The shared styles provide:
 | --- | --- |
 | Title | `class="title-slide"` with title, subtitle, and byline |
 | Section introduction | `class="section-slide"` with one central idea |
+| Topic outline | `class="outline-slide"`, a list with `class="outline-topics"`, and `aria-current="step"` on the current topic |
 | Explanation | A heading and a few short paragraphs or list items |
 | Comparison | `<div class="columns">` containing two `<div>` elements |
 | Code | A fenced Python block, usually 6–12 lines |
@@ -141,6 +149,10 @@ The shared styles provide:
 Use `$$ ... $$` for display equations and `$ ... $` for inline math. The sample
 also demonstrates a local `demo.js` with editable input and a reset button.
 Keep custom interaction code out of the Markdown and the shared initializer.
+
+Repeat the same topic outline at section transitions. The current topic appears
+in bold black, while the others appear in gray. A caption can identify the
+current teaching period. See Lecture 01 for the four-topic example.
 
 ## Standard visual toolkit
 

--- a/slides/lecture-01/assets/heldout-chinese.json
+++ b/slides/lecture-01/assets/heldout-chinese.json
@@ -1,0 +1,30 @@
+{
+  "data": [
+    {
+      "type": "scatter",
+      "mode": "lines+markers",
+      "name": "English + Chinese",
+      "x": [0, 8, 32],
+      "y": [54, 48, 35],
+      "line": { "width": 4 },
+      "marker": { "size": 12 },
+      "hovertemplate": "Merges: %{x}<br>Chinese tokens: %{y}<extra>English + Chinese</extra>"
+    },
+    {
+      "type": "scatter",
+      "mode": "lines+markers",
+      "name": "English only",
+      "x": [0, 8, 32],
+      "y": [54, 54, 54],
+      "line": { "width": 4, "dash": "dash" },
+      "marker": { "size": 12, "symbol": "square" },
+      "hovertemplate": "Merges: %{x}<br>Chinese tokens: %{y}<extra>English only</extra>"
+    }
+  ],
+  "layout": {
+    "xaxis": { "title": { "text": "Learned merges" }, "tickvals": [0, 8, 32], "range": [-1, 33] },
+    "yaxis": { "title": { "text": "Chinese tokens" }, "range": [0, 60], "gridcolor": "#dce2e7" },
+    "legend": { "orientation": "h", "x": 0.2, "y": 1.18 },
+    "showlegend": true
+  }
+}

--- a/slides/lecture-01/cs336-tokenization-review.md
+++ b/slides/lecture-01/cs336-tokenization-review.md
@@ -1,0 +1,286 @@
+# CS336 Lecture 1: Content and Tokenization Teaching Review
+
+**Source:** Percy Liang, Stanford CS336, Spring **2026**,
+[Lecture 1: Overview, Tokenization](https://www.youtube.com/watch?v=JuoVZkPBiKk).
+The course schedule dates the lecture March 30, 2026; the recording is 79:22 long.
+This review was prepared on September 8, 2026 from the complete English automatic
+captions and the official executable lecture source. Captions can contain
+transcription errors; code and numerical examples were checked separately.
+Timestamps below are approximate topic starts in **minutes:seconds**.
+[Course schedule](https://cs336.stanford.edu/#schedule) ·
+[Executable lecture](https://cs336.stanford.edu/lectures/?trace=lecture_01)
+
+**Main assessment:** Liang makes tokenization compelling by connecting it to
+compute efficiency, then building BPE from the limitations of simpler choices.
+For our class, keep that progression and give more time to **Unicode versus
+bytes**, **BPE training versus encoding**, and **what compression does and does
+not measure**. His detailed tokenization section lasts only about 14 minutes;
+the encoding walkthrough is explicitly skipped for time. The recommendations
+below are teaching judgments and proposed additions, separate from the summary
+of what he presents.
+
+## 1. Main content of the full lecture
+
+| Video position | Main content | Takeaway for our course |
+| --- | --- | --- |
+| [00:04–03:23](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4s) | Staff introductions and changes in the third course offering. | Explain what students will learn by building. |
+| [03:23–11:36](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=203s) | Motivation: abstractions hide mechanisms; small models teach mechanics and an efficiency mindset, while empirical intuitions may change with scale. | Organize the course around the best model achievable with limited resources. |
+| [11:36–19:26](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=696s) | Language-model history, the open-model ecosystem, and increasing importance of inference. | Give historical context without requiring students to memorize model releases. |
+| [19:26–27:17](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=1166s) | Executable lecture format, workload, assignments, AI tutoring policy, and compute access. | Connect explanations to inspectable programs and correctness checks. |
+| [27:17–35:53](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=1637s) | Basics: tokenization, architecture, optimization, and training; balance expressiveness, stability, and efficiency. | Position tokenization within the complete training pipeline. |
+| [35:53–45:12](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=2153s) | Systems: resource accounting, kernels, data movement, parallelism, and inference. | Explain why representation choices affect hardware work. |
+| [45:12–53:29](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=2712s) | Scaling recipes and predicting larger runs from smaller experiments. | Distinguish measured evidence from extrapolation. |
+| [53:29–60:20](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=3209s) | Evaluation, data collection, transformation, filtering, deduplication, and mixtures. | Data preparation is part of model building. |
+| [60:20–65:07](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=3620s) | Alignment and reinforcement learning, followed by a return to the resource-budget theme. | Relate the course units through their shared constraints. |
+| [65:07–79:15](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=3907s) | Detailed tokenization lesson, BPE implementation, and closing remarks. | This is the main segment to revisit for Lecture 01 preparation. |
+
+The first hour is principally a course overview. Tokenization gets an early
+preview at [28:05](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=1685s), where Liang
+connects shorter sequences and variable-size chunks to efficient computation.
+He returns to that motivation before and after the detailed lesson.
+
+## 2. How Liang presents tokenization
+
+### The sequence of explanations
+
+| Start | What he presents | Teaching function |
+| --- | --- | --- |
+| [65:22](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=3922s) | Raw Unicode text, integer token IDs, and an encode/decode interface. | Establish the input, output, and round-trip contract. |
+| [65:50](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=3950s) | An intended interactive tokenizer demo; internet access fails, so he describes spaces, repeated words, and digit groups. | Show surprising behavior before introducing the algorithm. |
+| [67:00](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4020s) | A real tokenizer encodes and decodes mixed English, Chinese, and emoji text; 20 bytes become 8 tokens. | Make the interface and bytes-per-token metric concrete. |
+| [68:28](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4108s) | Character tokenizer using `ord` and `chr`; vocabulary coverage and rarity problems. | Test the most direct mapping from an existing string representation. |
+| [69:44](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4184s) | UTF-8 byte tokenizer: 256 possible values, but longer sequences. | Exchange vocabulary complexity for sequence length. |
+| [70:44](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4244s) | Word-like chunks; shorter sequences, many rare words, and unseen-word handling. | Show the opposite extreme and motivate reusable subword pieces. |
+| [71:58](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4318s) | BPE intuition: learn frequent adjacent combinations, leaving rare material in smaller pieces. | Introduce a data-dependent compromise. |
+| [73:16](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4396s) | Three training merges on `the cat in the hat`, with new IDs and a shrinking sequence. | Connect pair counts, vocabulary growth, and compression through code. |
+| [75:21](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4521s) | Encode `the quick brown fox` using learned merges and decode it back. He skips stepping through the encoding code. | State the training/use distinction, but leave its mechanics mostly implicit. |
+| [76:02](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4562s) | Slow implementation, relevant merges, special tokens, and pre-tokenization. | Bridge the toy algorithm to implementation work. |
+| [77:29](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4649s) | Recap; future alternatives should also learn useful abstractions and allow variable computation. | Return from implementation details to the original motivation. |
+
+### What works well
+
+His progression gives students a reason to want BPE before seeing its loop.
+Each baseline has a recognizable benefit and a cost. Reusing the same interface
+also keeps the conceptual task stable while the implementation changes.
+
+The executable lecture exposes intermediate state: IDs, pair counts, vocabulary
+entries, and reconstructed text. This is especially useful at
+[73:37–75:05](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4417s), where a merge
+becomes an operation students can inspect rather than an abstract instruction.
+
+The weakness is pacing for beginners. At
+[68:30](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4110s) he announces a fast
+walkthrough; at [75:44](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4544s) he
+skips the encoding code. Our lesson should preserve the reasoning while adding
+prediction pauses and a complete example on unseen text.
+
+## 3. Where the explanation can be clearer
+
+These are proposed improvements for our students, not claims that Liang's
+lecture source lacks every relevant detail.
+
+| Priority | Passage and possible confusion | Concrete improvement |
+| --- | --- | --- |
+| Highest | **Training versus encoding**, 73:16–75:58: students may recount frequent pairs in each new input. | Place two workflows side by side: training learns vocabulary and merge priority; encoding uses those fixed objects. Trace every merge on unseen text. |
+| Highest | **Characters, bytes, and tokens**, 68:28–70:42: all appear as integers, making them easy to conflate. | Give one string three rows: Unicode code points, UTF-8 bytes, and tokenizer IDs. Include Chinese and emoji. Explain that IDs identify vocabulary entries; embeddings are learned later by the model. |
+| Highest | **Compression**, 67:25–68:19: a larger number may sound like a universally better tokenizer or smaller file. | Label the metric “UTF-8 bytes per token.” Hold the text fixed; report vocabulary size and held-out results alongside it. Distinguish token count, runtime, storage size, and model quality. |
+| High | **Merge mechanics**, 73:37–75:05: ties and overlapping pairs can be missed during code stepping. | State the tie rule, count adjacent pairs, apply non-overlapping replacements, then recount. Show `aaa` as a separate edge case. |
+| High | **Pre-tokenization**, 76:53–77:09: it is introduced mainly as a speed improvement. | Draw allowed chunk boundaries and show that BPE cannot merge across them. Boundary rules change the learned vocabulary and segmentation as well as runtime. |
+| High | **Round trips**, 65:37–65:47 and 67:14–67:23: students may think every token is independently readable text. | Display token bytes and concatenate them before UTF-8 decoding. State the contract for supported text without lossy normalization; arbitrary generated IDs need not form valid UTF-8. |
+| Medium | **Variable computation**, 28:55–29:15 and 78:41–78:56: “interesting” chunks could sound like semantic understanding. | Explain that BPE uses corpus frequency, not a learned judgment of meaning or difficulty. Rare strings often require more token positions; this is a heuristic allocation of work. |
+| Medium | **Tokenizer quirks**, 65:50–66:57: the intended live demo is unavailable. | Prepare an offline example with token IDs and byte pieces. Ask students to predict the effect of a leading space, an emoji, or a new word before revealing output. |
+
+### A. Separate representation from meaning
+
+Use Liang's exact mixed-text example, `Hello, 🌍! 你好!`, and compare:
+
+| Representation | Sequence length | Meaning of an element |
+| --- | ---: | --- |
+| Unicode code points | 13 | One code point value |
+| UTF-8 bytes | 20 | One integer from 0 to 255 |
+| `o200k_base` tokens | 8 | One vocabulary entry representing a byte sequence |
+
+The following is a **locally verified expansion** of the lecture example,
+using `tiktoken` 0.14.0 and the explicit encoding name `o200k_base`:
+
+```python
+import tiktoken
+
+text = "Hello, 🌍! 你好!"
+encoding = tiktoken.get_encoding("o200k_base")
+ids = encoding.encode(text)
+pieces = [encoding.decode_single_token_bytes(i) for i in ids]
+assert len(text) == 13 and len(text.encode("utf-8")) == 20
+assert len(ids) == 8
+assert b"".join(pieces) == text.encode("utf-8")
+assert encoding.decode(ids) == text
+```
+
+The emoji is split across two token byte sequences: one ends with
+`b'\xf0\x9f\x8c'` after a leading space, and the next is `b'\x8d'`.
+Neither token can independently reconstruct that emoji. Meanwhile, `你好`
+occupies one token here. A token can therefore be smaller than a code point or
+contain several code points. These are measured properties of this encoding,
+not universal rules for Chinese or emoji.
+
+For a second small example, `é` and `e\u0301` can look alike but contain one and
+two code points, respectively. A visible symbol is not a reliable counting unit.
+Use the [Python Unicode HOWTO, Definitions and Encodings](https://docs.python.org/3/howto/unicode.html#definitions)
+to distinguish code points from their byte representation.
+
+### B. Finish the BPE walkthrough on both training and unseen text
+
+This reconstruction uses Liang's toy corpus and the published algorithm.
+It starts with **all 256 byte values**, has no special tokens or pre-tokenizer,
+and resolves tied pair counts by their first encounter while scanning left to
+right. Spaces below are actual bytes; `␠` is only a display label.
+[Video walkthrough](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4396s) ·
+[Published training function][training-source]
+
+| Step | Selected pair | Pair count | New ID and byte content | Tokens in training text | Vocabulary size |
+| --- | --- | ---: | --- | ---: | ---: |
+| Initial | — | — | IDs 0–255 each represent one byte | 18 | 256 |
+| 1 | `t` + `h` | 2 | 256 → `b'th'` | 16 | 257 |
+| 2 | `th` + `e` | 2 | 257 → `b'the'` | 14 | 258 |
+| 3 | `the` + `␠` | 2 | 258 → `b'the '` | 12 | 259 |
+
+After three merges, the training-text ratio is `18 / 12 = 1.5` bytes per
+token. Keep the original byte entries: merging adds an entry rather than
+deleting the constituent tokens. The stored artifacts are a vocabulary mapping
+IDs to bytes and an ordered list of merge rules.
+
+Now **freeze those artifacts** and encode `the quick brown fox`:
+
+```text
+Start:  t | h | e | ␠ | q | u | i | c | k | ␠ | b | r | o | w | n | ␠ | f | o | x
+Rule 1: th | e | ␠ | q | u | i | c | k | ␠ | b | r | o | w | n | ␠ | f | o | x
+Rule 2: the | ␠ | q | u | i | c | k | ␠ | b | r | o | w | n | ␠ | f | o | x
+Rule 3: the␠ | q | u | i | c | k | ␠ | b | r | o | w | n | ␠ | f | o | x
+```
+
+The result has 16 tokens for 19 bytes. The words `quick`, `brown`, and `fox`
+were absent from the training string, but their bytes remain representable.
+No unknown-word token or new vocabulary entry is needed. Decoding looks up
+each ID's bytes, concatenates them, and decodes the complete byte sequence.
+[Published encoder and decoder][encoder-source]
+
+Have students explain three observations before running anything:
+
+- Training selects pairs by their frequency in the current training sequences;
+  encoding follows the learned priority without retraining on the new input.
+- A merge rule can join tokens that already represent multiple bytes. BPE does
+  not stop after creating two-byte pieces.
+- An unseen word is encodable because the byte vocabulary is complete. That
+  does not imply that the language model understands the word.
+
+For overlap, `a a a` contains two adjacent `a a` pairs, but a left-to-right
+replacement produces `aa a`, reducing three tokens to two. Pair frequency and
+the number of replacements are different when occurrences overlap.
+
+### C. Make the efficiency tradeoff measurable
+
+For a fixed nonempty text, define
+
+$$
+C = \frac{\text{UTF-8 byte count}}{\text{token count}}.
+$$
+
+If `C` doubles on that same text, its token count halves. With fixed model
+dimensions, the quadratic component of dense self-attention then involves
+about one quarter as many position pairs. This is an explanation of one cost
+component, not a promise of a fourfold end-to-end speedup: other computation,
+memory traffic, vocabulary projection, and implementation choices also matter.
+This calculation follows from the attention equation and complexity comparison
+in [Vaswani et al., Sections 3.2.1 and 4](https://arxiv.org/html/1706.03762v7#S3.SS2.SSS1).
+
+Vocabulary growth also has a concrete cost. An embedding table with `V` entries
+of dimension `d` has `V × d` parameters. In a toy calculation with `d = 1024`,
+increasing `V` from 32,000 to 128,000 adds 98,304,000 embedding parameters.
+An untied output matrix adds its own parameters; weight tying changes that
+accounting. More entries also spread observations over more distinct pieces.
+See [Vaswani et al., Section 3.4](https://arxiv.org/html/1706.03762v7#S3.SS4)
+for embeddings and weight sharing; the parameter totals here are our calculation.
+
+For our class, compare tokenizers on the same **held-out** English and Chinese
+texts. Record the encoding name, vocabulary size, bytes, tokens, and bytes per
+token. Interpret results separately by language. Higher bytes per token alone
+does not establish better semantic representations, lower storage size, or
+better language-model predictions. Raw per-token perplexities also have
+different units when the tokenizations differ.
+
+## 4. Suggested adaptation for our Lecture 01
+
+Use Liang's sequence as the conceptual backbone. A proposed **45-minute
+tokenization block**, following the initial Unicode introduction, is:
+
+| Minutes | Focus | Student action |
+| --- | --- | --- |
+| 0–5 | Interface and mixed-text example | Predict code point, byte, and token counts. |
+| 5–12 | Character, byte, and word choices | Explain one cost of each using a comparison table. |
+| 12–22 | BPE training | Count pairs, resolve a tie, trace merges, and explain overlaps. |
+| 22–31 | Frozen vocabulary and encoding | Encode unseen text and reconstruct its bytes. |
+| 31–36 | Boundaries and special tokens | Explain why a boundary forbids a possible merge; distinguish a reserved control ID from its displayed spelling. |
+| 36–43 | Held-out comparison | Interpret English and Chinese token counts and identify a missing quality metric. |
+| 43–45 | Exit check | Explain why encoding an unseen word does not train the tokenizer. |
+
+For a boundary example, a pre-tokenizer might separate `the` and its following
+space. In that case the toy merge `the + ␠` would be forbidden. Choose and show
+an actual rule before comparing outputs; pre-tokenization conventions differ.
+The original NLP BPE formulation applies merges within words with a boundary
+symbol, which differs from Liang's unrestricted toy byte stream.
+[Sennrich et al. (2016), Section 3.2](https://aclanthology.org/P16-1162.pdf#page=3)
+
+The existing [teaching plan](teaching-plan.md) already reserves time for Unicode,
+BPE training, fixed merge order, and held-out comparison. Its `low` × 5 and
+`lower` × 2 example is suitable: keep its declared tie rule and explicitly
+separate training strings. It need not reproduce Stanford's different toy
+corpus or tie policy.
+
+When implementing these recommendations in [slides.md](slides.md) and the
+[exercise notebook](lecture-01-exercise.ipynb), synchronize exercise IDs and
+solutions with the teaching plan. This review supplies preparation notes;
+the proposed activities are not new published exercise assignments.
+
+## 5. Accuracy notes when adapting the recording
+
+- **Use the correct edition.** This video is Spring 2026. Searches often return
+  the similarly titled 2025 lecture. Its timing and contents should not be
+  substituted for this recording.
+- **Name the encoding.** Liang labels the real example as a GPT-5 tokenizer;
+  the source specifically loads `o200k_base`. Use that explicit name when
+  reproducing this demonstration, since model labels alone are insufficient
+  specifications. [Source function][encoding-source]
+- **Correct the historical shortcut.** Around
+  [72:19](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4339s), the spoken account
+  identifies GPT-2 as the first use of BPE for language models. The 2018 GPT
+  paper already describes BPE with 40,000 merges. Teach that GPT-2 used BPE,
+  without the priority claim.
+  [Radford et al. (2018), Section 4.1, Model specifications](https://cdn.openai.com/research-covers/language-unsupervised/language_understanding_paper.pdf#page=5)
+- **Avoid a timeless Unicode count.** Liang's approximate character count is
+  background context. More fundamentally, raw code point IDs are not a dense
+  vocabulary: `max(ids) + 1` measures the table size needed for direct indexing,
+  not the number of distinct characters observed. Reindexing characters is a
+  separate choice. [Python Unicode definitions](https://docs.python.org/3/howto/unicode.html#definitions)
+- **Qualify the baseline verdict.** The lecture's efficiency argument concerns
+  its model setting. Character and byte representations remain useful
+  baselines; the closing discussion itself leaves room for architectures that
+  learn how to group bytes.
+  [Closing discussion](https://www.youtube.com/watch?v=JuoVZkPBiKk&t=4681s)
+
+## 6. Verification and source details
+
+The source links below are pinned to commit
+`607a238629cf5332f71085d19c97dff41decf661`, the latest change to `lecture_01.py`
+reported by the official repository when retrieved. This is the published
+source consulted, not a claim that this commit was used on the recording date.
+The relevant spoken examples were cross-checked against the captions.
+
+Verification used the project Python environment with `uv run --no-sync python`.
+The published toy functions were run without the lecture viewer. Checks covered
+all three merges, vocabulary sizes, training and unseen-text lengths, round
+trips, overlap behavior, the mixed-text `o200k_base` example, and the embedding
+parameter calculation. The full caption transcript is not reproduced here.
+
+[training-source]: https://github.com/stanford-cs336/lectures/blob/607a238629cf5332f71085d19c97dff41decf661/lecture_01.py#L729-L759
+[encoder-source]: https://github.com/stanford-cs336/lectures/blob/607a238629cf5332f71085d19c97dff41decf661/lecture_01.py#L542-L564
+[encoding-source]: https://github.com/stanford-cs336/lectures/blob/607a238629cf5332f71085d19c97dff41decf661/lecture_01.py#L574-L576

--- a/slides/lecture-01/lecture-01-exercise.ipynb
+++ b/slides/lecture-01/lecture-01-exercise.ipynb
@@ -1,103 +1,1019 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Lecture 01: Tokenization\n",
-        "\n",
-        "Exercises follow the examples and exercise IDs in lecture-01-slides.\n"
-      ],
-      "id": "cell-00"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Code points and UTF-8 bytes\n",
-        "\n",
-        "Predict the counts before running the cell.\n"
-      ],
-      "id": "cell-01"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "examples = [\"hello\", \"你好\", \"🙂\"]\n",
-        "\n",
-        "for text in examples:\n",
-        "    code_points = len(text)\n",
-        "    utf8_bytes = len(text.encode(\"utf-8\"))\n",
-        "    print(text, code_points, utf8_bytes)\n"
-      ],
-      "id": "cell-02"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## E01: Which pair merges first?\n",
-        "\n",
-        "The word `aaab` occurs twice and `ab` occurs once. Count adjacent pairs by hand, including overlaps. Then check your answer below.\n"
-      ],
-      "id": "cell-03"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from collections import Counter\n",
-        "\n",
-        "corpus = {\"aaab\": 2, \"ab\": 1}\n",
-        "pairs = Counter()\n",
-        "for word, frequency in corpus.items():\n",
-        "    for pair in zip(word, word[1:]):\n",
-        "        pairs[pair] += frequency\n",
-        "print(pairs)\n",
-        "assert pairs[(\"a\", \"a\")] == 4\n",
-        "assert pairs[(\"a\", \"b\")] == 3\n"
-      ],
-      "id": "cell-04"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Sequence length\n",
-        "\n",
-        "Check the totals for `low` (frequency 5) and `lower` (frequency 2) after each merge.\n"
-      ],
-      "id": "cell-05"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "stages = [(3, 5), (2, 4), (1, 3)]\n",
-        "totals = [5 * low_length + 2 * lower_length for low_length, lower_length in stages]\n",
-        "print(totals)\n",
-        "assert totals == [25, 18, 11]\n"
-      ],
-      "id": "cell-06"
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "introduction",
+   "metadata": {},
+   "source": [
+    "# Lecture 01: Introduction and Tokenization\n",
+    "\n",
+    "CS40008.01 · Baojian Zhou · Fudan University · September 9, 2026\n",
+    "\n",
+    "**Question:** How does an LLM application turn our text into something a model can predict?\n",
+    "\n",
+    "This notebook accompanies the three 45-minute lecture periods. Run the cells in order;\n",
+    "predict each exercise's result before running its check. E01–E05 are ungraded classroom practice.\n",
+    "\n",
+    "1. **Course overview:** call Ollama for sentiment, translation, and generation (E01).\n",
+    "2. **Development of NLP and LLMs:** connect model responses to next-token prediction.\n",
+    "3. **Text preprocessing:** inspect Unicode and UTF-8 (E02).\n",
+    "4. **Text tokenization:** train BPE, encode unseen text, and compare vocabularies (E03–E05).\n",
+    "\n",
+    "The final section contains further experiments with token log probabilities, thinking,\n",
+    "vision, and existing tokenizer vocabularies. These are opt-in.\n",
+    "\n",
+    "Keep your work in the personal copy under `workspace/`. If you already opened an earlier\n",
+    "handout, rename that personal notebook in JupyterLab, then click **Notebook** in the slides\n",
+    "again to receive a fresh copy. Your renamed notebook retains your earlier work."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "setup",
+   "metadata": {},
+   "source": [
+    "## Before running the local-model examples\n",
+    "\n",
+    "The course's `uv` environment supplies Python and JupyterLab. **Ollama is a separate\n",
+    "application**, not a Python dependency. Install it from [ollama.com](https://ollama.com/download),\n",
+    "start the app (or run `ollama serve` in another terminal), then run:\n",
+    "\n",
+    "```sh\n",
+    "ollama pull qwen3:0.6b\n",
+    "ollama list\n",
+    "```\n",
+    "\n",
+    "Download the model before class; cells below never install or download an Ollama model.\n",
+    "The small model makes classroom experiments manageable, but it can make mistakes.\n",
+    "Use `qwen3:1.7b` instead if it is already installed and your computer can run it.\n",
+    "\n",
+    "The notebook sends requests to your local Ollama server at `127.0.0.1:11434`. It needs no\n",
+    "API key or extra Python SDK. If Ollama is unavailable, the model demonstrations explain\n",
+    "why they are skipped; **all core tokenization exercises still run offline**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "imports",
+   "metadata": {
+    "tags": [
+     "definitions"
+    ]
+   },
+   "source": [
+    "import base64\n",
+    "import json\n",
+    "import math\n",
+    "import os\n",
+    "import socket\n",
+    "import unicodedata\n",
+    "from collections import Counter\n",
+    "from pathlib import Path\n",
+    "from urllib.error import HTTPError, URLError\n",
+    "from urllib.request import ProxyHandler, Request, build_opener"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "ollama-client",
+   "metadata": {
+    "tags": [
+     "definitions"
+    ]
+   },
+   "source": [
+    "OLLAMA_URL = \"http://127.0.0.1:11434\"\n",
+    "MODEL = \"qwen3:0.6b\"\n",
+    "RUN_OLLAMA = os.environ.get(\"COURSE_RUN_OLLAMA\", \"1\") == \"1\"\n",
+    "local_http = build_opener(ProxyHandler({}))  # Do not proxy local requests.\n",
+    "\n",
+    "\n",
+    "def ollama_request(endpoint, payload=None, timeout=120):\n",
+    "    \"\"\"GET model information or POST one non-streaming JSON request.\"\"\"\n",
+    "    data = None if payload is None else json.dumps(payload).encode(\"utf-8\")\n",
+    "    request = Request(OLLAMA_URL + endpoint, data=data,\n",
+    "                      headers={\"Content-Type\": \"application/json\"})\n",
+    "    try:\n",
+    "        with local_http.open(request, timeout=timeout) as response:\n",
+    "            result = json.load(response)\n",
+    "    except HTTPError as error:\n",
+    "        detail = error.read().decode(\"utf-8\", errors=\"replace\")\n",
+    "        raise RuntimeError(f\"Ollama HTTP {error.code}: {detail}\") from error\n",
+    "    except (URLError, socket.timeout, TimeoutError, ConnectionError) as error:\n",
+    "        raise RuntimeError(\"Cannot reach Ollama, or the request timed out. \"\n",
+    "                           \"Start Ollama and check the installed model.\") from error\n",
+    "    if not isinstance(result, dict):\n",
+    "        raise RuntimeError(\"Expected a JSON object from Ollama.\")\n",
+    "    if result.get(\"error\"):\n",
+    "        raise RuntimeError(f\"Ollama: {result['error']}\")\n",
+    "    return result"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "ollama-status",
+   "metadata": {
+    "tags": [
+     "requires-ollama"
+    ]
+   },
+   "source": [
+    "OLLAMA_READY = False\n",
+    "if RUN_OLLAMA:\n",
+    "    try:\n",
+    "        installed_models = ollama_request(\"/api/tags\", timeout=3)[\"models\"]\n",
+    "        selected = next((m for m in installed_models if m[\"name\"] == MODEL), None)\n",
+    "        if selected:\n",
+    "            OLLAMA_READY = True\n",
+    "            print(\"Model:\", MODEL)\n",
+    "            print(\"Digest:\", selected[\"digest\"])\n",
+    "        else:\n",
+    "            print(f\"Install the selected model in a terminal: ollama pull {MODEL}\")\n",
+    "            print(\"Already installed:\", [m[\"name\"] for m in installed_models])\n",
+    "    except RuntimeError as error:\n",
+    "        print(error)\n",
+    "else:\n",
+    "    print(\"Ollama calls disabled for this run.\")\n",
+    "if not OLLAMA_READY:\n",
+    "    print(\"Continue with predictions and E02–E05; they do not require Ollama.\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "first-call-intro",
+   "metadata": {},
+   "source": [
+    "## One prompt, one response\n",
+    "\n",
+    "The request sets `stream=False` to receive one JSON object. `think=False` disables the\n",
+    "Qwen3 thinking output for these short classroom calls. `temperature=0` selects greedy\n",
+    "generation; this is useful for comparisons but does not guarantee identical output across\n",
+    "different model files, runtimes, or hardware. `num_predict` limits generated tokens.\n",
+    "\n",
+    "First predict the answer. Then inspect the **actual** response, its token counts, and its\n",
+    "stop reason. `prompt_eval_count` includes the model's prompt formatting; it is not a\n",
+    "standalone tokenization of just the visible prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "first-call",
+   "metadata": {
+    "tags": [
+     "requires-ollama"
+    ]
+   },
+   "source": [
+    "first_response = None\n",
+    "if OLLAMA_READY:\n",
+    "    first_response = ollama_request(\"/api/generate\", {\n",
+    "        \"model\": MODEL,\n",
+    "        \"prompt\": \"Fudan University is located in which city? Answer with one word.\",\n",
+    "        \"stream\": False,\n",
+    "        \"think\": False,\n",
+    "        \"options\": {\"temperature\": 0, \"seed\": 42, \"num_predict\": 48},\n",
+    "    })\n",
+    "    print(first_response[\"response\"])\n",
+    "    print({key: first_response.get(key) for key in\n",
+    "           [\"prompt_eval_count\", \"eval_count\", \"done_reason\"]})"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "first-call-check",
+   "metadata": {},
+   "source": [
+    "**Check:** the expected city is **Shanghai**. If the model names another city,\n",
+    "record that factual error. A confident or short answer can still be wrong.\n",
+    "The optional log-probability experiment revisits this exact prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "generate-helper",
+   "metadata": {
+    "tags": [
+     "definitions"
+    ]
+   },
+   "source": [
+    "def generate(prompt, *, temperature=0, max_tokens=96, **extra):\n",
+    "    \"\"\"Reuse the same model and bounded settings for the next experiments.\"\"\"\n",
+    "    if not OLLAMA_READY:\n",
+    "        print(\"Skipped model call: Ollama/model is unavailable or calls are disabled.\")\n",
+    "        return None\n",
+    "    payload = {\n",
+    "        \"model\": MODEL, \"prompt\": prompt, \"stream\": False, \"think\": False,\n",
+    "        \"options\": {\"temperature\": temperature, \"seed\": 42,\n",
+    "                    \"num_predict\": max_tokens},\n",
+    "    }\n",
+    "    payload.update(extra)\n",
+    "    result = ollama_request(\"/api/generate\", payload)\n",
+    "    print(result.get(\"response\", \"\"))\n",
+    "    if result.get(\"done_reason\") == \"length\":\n",
+    "        print(\"[Token limit reached: the answer may be incomplete.]\")\n",
+    "    return result"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e01",
+   "metadata": {},
+   "source": [
+    "## E01 · Sentiment and context · 5 minutes\n",
+    "\n",
+    "These camera reviews come from the previous Fudan Lecture 01. Label each as **Positive**,\n",
+    "**Negative**, or **Neutral** before running the model. Explain how “light” changes meaning.\n",
+    "\n",
+    "1. Nice and compact to carry!\n",
+    "2. Since the camera is small and light, I won't need to carry around those heavy, bulky professional cameras either!\n",
+    "3. The camera feels flimsy, is plastic and very light in weight you have to be very delicate in the handling of this camera.\n",
+    "\n",
+    "**Your predictions and reasons:** replace this sentence with your notes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "sentiment",
+   "metadata": {
+    "tags": [
+     "requires-ollama"
+    ]
+   },
+   "source": [
+    "reviews = [\n",
+    "    \"Nice and compact to carry!\",\n",
+    "    \"Since the camera is small and light, I won't need to carry around those \"\n",
+    "    \"heavy, bulky professional cameras either!\",\n",
+    "    \"The camera feels flimsy, is plastic and very light in weight you have to \"\n",
+    "    \"be very delicate in the handling of this camera.\",\n",
+    "]\n",
+    "sentiment_results = []\n",
+    "for review in reviews:\n",
+    "    print(\"\\nReview:\", review)\n",
+    "    result = generate(\n",
+    "        \"Classify the sentiment as Positive, Negative, or Neutral. \"\n",
+    "        \"Return JSON with keys label and reason. Use at most 12 words for the reason. \"\n",
+    "        \"Text: \" + review, format=\"json\",\n",
+    "    )\n",
+    "    sentiment_results.append(result)\n",
+    "    if result:\n",
+    "        try:\n",
+    "            answer = json.loads(result[\"response\"])\n",
+    "            valid = (isinstance(answer, dict)\n",
+    "                     and answer.get(\"label\") in {\"Positive\", \"Negative\", \"Neutral\"}\n",
+    "                     and isinstance(answer.get(\"reason\"), str))\n",
+    "            print(\"Expected label/reason structure:\", valid)\n",
+    "            if valid:\n",
+    "                print(\"Reason uses at most 12 words:\", len(answer[\"reason\"].split()) <= 12)\n",
+    "        except (json.JSONDecodeError, KeyError):\n",
+    "            print(\"The response was incomplete or not valid JSON; inspect it above.\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e01-check",
+   "metadata": {},
+   "source": [
+    "**Check:** expected human labels are Positive, Positive, Negative. “Light” can describe\n",
+    "portability or flimsy construction. Model output can disagree. Valid JSON checks the\n",
+    "response format, not its correctness. Three examples are enough to discuss behavior,\n",
+    "but not to estimate real-world accuracy.\n",
+    "\n",
+    "Change only the prompt, then rerun. Did the labels change? Keep your original observations\n",
+    "so you can compare. Do not treat a model's self-reported confidence as calibrated accuracy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "translation-intro",
+   "metadata": {},
+   "source": [
+    "## Translation and generation\n",
+    "\n",
+    "The translation example adapts the AI definition from the previous lecture. Check that\n",
+    "the English preserves the meaning without adding facts. For generation, check that the\n",
+    "model follows both the requested length and the supplied course facts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "translation-generation",
+   "metadata": {
+    "tags": [
+     "requires-ollama"
+    ]
+   },
+   "source": [
+    "chinese_text = (\n",
+    "    \"人工智能亦称机器智能，指由人制造出来的机器所表现出来的智能。\"\n",
+    "    \"通常人工智能是指通过计算机程序来呈现人类智能的技术。\"\n",
+    ")\n",
+    "translation = generate(\"Translate into English. Return only the translation:\\n\"\n",
+    "                       + chinese_text, max_tokens=128)\n",
+    "welcome = generate(\n",
+    "    \"Write a two-sentence welcome for Fudan's course on NLP and LLMs. \"\n",
+    "    \"Mention today's topic: tokenization. Do not invent course requirements.\",\n",
+    "    max_tokens=96,\n",
+    ")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "development",
+   "metadata": {},
+   "source": [
+    "## Connecting the response to a language model\n",
+    "\n",
+    "The same model can receive instructions for different tasks. Generation predicts tokens\n",
+    "one after another, conditioned on the earlier tokens. Prompting changes that context;\n",
+    "it does not update the model's weights. A fluent continuation is not necessarily correct.\n",
+    "\n",
+    "The lecture traces rules and statistical models, learned representations, the Transformer,\n",
+    "and prompting. To build a language model, we must choose data, a tokenizer, model/training\n",
+    "settings, and an evaluation method. We now implement the tokenizer part."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "preprocessing-intro",
+   "metadata": {},
+   "source": [
+    "## Preserve the intended text\n",
+    "\n",
+    "Inspect the two spaces, newline, and capitalization. Lowercasing changes the input;\n",
+    "`strip()` removes whitespace at the ends, not the spaces and newline inside this string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "preprocessing-code",
+   "metadata": {},
+   "source": [
+    "text = \"Hello,  世界!\\n🙂\"\n",
+    "print(repr(text))\n",
+    "print(repr(text.lower().strip()))\n",
+    "assert text != text.lower().strip()\n",
+    "assert text.strip() == text"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e02",
+   "metadata": {},
+   "source": [
+    "## E02 · Code points, bytes, and normalization · 3 minutes\n",
+    "\n",
+    "Predict `len(text)` and `len(text.encode(\"utf-8\"))` for the examples below.\n",
+    "The two accented strings look alike; the second uses `e` followed by a combining accent.\n",
+    "\n",
+    "**Your predictions:** replace this sentence before running the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "unicode-counts",
+   "metadata": {},
+   "source": [
+    "examples = [\"hello\", \"你好\", \"🙂\", \"é\", \"e\\u0301\", \"你好🙂\"]\n",
+    "for text in examples:\n",
+    "    print(repr(text), \"code points:\", len(text),\n",
+    "          \"UTF-8 bytes:\", len(text.encode(\"utf-8\")))\n",
+    "    assert text.encode(\"utf-8\").decode(\"utf-8\") == text\n",
+    "\n",
+    "assert \"é\" != \"e\\u0301\"\n",
+    "assert unicodedata.normalize(\"NFC\", \"e\\u0301\") == \"é\"\n",
+    "print(\"NFC can make these strings equal, but changes the original representation.\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e02-check",
+   "metadata": {},
+   "source": [
+    "**Check:** `hello` gives 5 / 5; `你好` 2 / 6; `🙂` 1 / 4; `é` 1 / 2;\n",
+    "`e\\u0301` 2 / 3; `你好🙂` 3 / 10. These are code points and bytes, not model-token counts.\n",
+    "Our tokenizer preserves the exact input; it does not lowercase or normalize it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "byte-baseline",
+   "metadata": {},
+   "source": [
+    "text = \"你好🙂\"\n",
+    "byte_ids = list(text.encode(\"utf-8\"))\n",
+    "print(\"Byte IDs:\", byte_ids)\n",
+    "print(\"Full round trip:\", bytes(byte_ids).decode(\"utf-8\"))\n",
+    "try:\n",
+    "    print(bytes(byte_ids[:1]).decode(\"utf-8\"))\n",
+    "except UnicodeDecodeError:\n",
+    "    print(\"One byte of this character is not a complete UTF-8 character.\")\n",
+    "assert bytes(byte_ids).decode(\"utf-8\") == text"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bpe-intro",
+   "metadata": {},
+   "source": [
+    "## Train a byte BPE tokenizer\n",
+    "\n",
+    "We retain all 256 base bytes. Each merge creates one additional token whose value is\n",
+    "the concatenation of two existing byte strings. No unknown token is needed for unseen\n",
+    "valid UTF-8 text. Token IDs are specific to this vocabulary and cannot be passed to Qwen.\n",
+    "\n",
+    "This teaching implementation follows the training/encoding distinction in\n",
+    "[CS336 Lecture 1](https://cs336.stanford.edu/lectures/?trace=lecture_01).\n",
+    "It scans sequences repeatedly to keep the mechanism visible. It has no production\n",
+    "pre-tokenizer, special-token parser, or chat template. Each input string is a separate\n",
+    "sequence; merges never cross between strings.\n",
+    "\n",
+    "**Tie rule:** among pairs with the highest count, choose the smallest tuple of token IDs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "pair-counts-definition",
+   "metadata": {
+    "tags": [
+     "bpe-definition"
+    ]
+   },
+   "source": [
+    "def count_pairs(sequences):\n",
+    "    \"\"\"sequences contains (token_ids, frequency); count overlaps within each one.\"\"\"\n",
+    "    counts = Counter()\n",
+    "    for ids, frequency in sequences:\n",
+    "        for pair in zip(ids, ids[1:]):\n",
+    "            counts[pair] += frequency\n",
+    "    return counts\n",
+    "\n",
+    "\n",
+    "def merge_pair(ids, pair, new_id):\n",
+    "    \"\"\"Replace non-overlapping occurrences from left to right.\"\"\"\n",
+    "    result = []\n",
+    "    index = 0\n",
+    "    while index < len(ids):\n",
+    "        if tuple(ids[index:index + 2]) == pair:\n",
+    "            result.append(new_id)\n",
+    "            index += 2\n",
+    "        else:\n",
+    "            result.append(ids[index])\n",
+    "            index += 1\n",
+    "    return result"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "train-definition",
+   "metadata": {
+    "tags": [
+     "bpe-definition"
+    ]
+   },
+   "source": [
+    "def train_bpe(corpus, num_merges):\n",
+    "    \"\"\"Return vocabulary, ordered merges, and weighted token totals.\"\"\"\n",
+    "    if type(num_merges) is not int or num_merges < 0:\n",
+    "        raise ValueError(\"num_merges must be a non-negative integer\")\n",
+    "    sequences = []\n",
+    "    for text, frequency in corpus:\n",
+    "        if not isinstance(text, str) or type(frequency) is not int or frequency <= 0:\n",
+    "            raise ValueError(\"Each corpus item needs text and a positive integer frequency\")\n",
+    "        sequences.append((list(text.encode(\"utf-8\")), frequency))\n",
+    "    vocab = {index: bytes([index]) for index in range(256)}\n",
+    "    merges = []\n",
+    "    totals = [sum(len(ids) * frequency for ids, frequency in sequences)]\n",
+    "    for _ in range(num_merges):\n",
+    "        counts = count_pairs(sequences)\n",
+    "        if not counts:\n",
+    "            break\n",
+    "        pair = min(counts, key=lambda pair: (-counts[pair], pair))\n",
+    "        new_id = len(vocab)\n",
+    "        vocab[new_id] = vocab[pair[0]] + vocab[pair[1]]\n",
+    "        merges.append((pair, new_id))\n",
+    "        sequences = [(merge_pair(ids, pair, new_id), frequency)\n",
+    "                     for ids, frequency in sequences]\n",
+    "        totals.append(sum(len(ids) * frequency for ids, frequency in sequences))\n",
+    "    return vocab, merges, totals"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "tokenizer-definition",
+   "metadata": {
+    "tags": [
+     "bpe-definition"
+    ]
+   },
+   "source": [
+    "class ByteBPETokenizer:\n",
+    "    def __init__(self, vocab, merges):\n",
+    "        self.vocab = dict(vocab)\n",
+    "        self.merges = list(merges)\n",
+    "\n",
+    "    def encode(self, text):\n",
+    "        ids = list(text.encode(\"utf-8\"))\n",
+    "        for pair, new_id in self.merges:\n",
+    "            ids = merge_pair(ids, pair, new_id)\n",
+    "        return ids\n",
+    "\n",
+    "    def decode(self, ids):\n",
+    "        return b\"\".join(self.vocab[index] for index in ids).decode(\"utf-8\")\n",
+    "\n",
+    "    def pieces(self, text):\n",
+    "        return [self.vocab[index] for index in self.encode(text)]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e03",
+   "metadata": {},
+   "source": [
+    "## E03 · Overlapping pairs · 4 minutes\n",
+    "\n",
+    "Training corpus: `aaab` × 2 and `ab` × 1. Which pair wins? Predict the weighted\n",
+    "total token count after one merge. Remember that counting and replacement handle\n",
+    "overlaps differently.\n",
+    "\n",
+    "**Your counts and predicted total:** replace this sentence before running the check."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "overlap-check",
+   "metadata": {},
+   "source": [
+    "overlap_corpus = [(\"aaab\", 2), (\"ab\", 1)]\n",
+    "sequences = [(list(text.encode(\"utf-8\")), frequency)\n",
+    "             for text, frequency in overlap_corpus]\n",
+    "counts = count_pairs(sequences)\n",
+    "print({bytes(pair): count for pair, count in counts.items()})\n",
+    "overlap_vocab, overlap_merges, overlap_totals = train_bpe(overlap_corpus, 1)\n",
+    "overlap_tokenizer = ByteBPETokenizer(overlap_vocab, overlap_merges)\n",
+    "print(\"After one merge:\", overlap_tokenizer.pieces(\"aaab\"))\n",
+    "print(\"Weighted totals:\", overlap_totals)\n",
+    "assert counts[(97, 97)] == 4 and counts[(97, 98)] == 3\n",
+    "assert overlap_totals == [10, 8]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e03-check",
+   "metadata": {},
+   "source": [
+    "**Check:** `aa` has four adjacent occurrences, but only two non-overlapping replacements\n",
+    "across the weighted corpus. Each `aaab` becomes `[aa, a, b]`; `ab` is unchanged.\n",
+    "The weighted total falls from 10 to 8, not to 6."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "low-corpus",
+   "metadata": {},
+   "source": [
+    "### Reproduce the lecture's two merges\n",
+    "\n",
+    "Treat `low` and `lower` as separate sequences. The first tie is between `(l, o)` and\n",
+    "`(o, w)`; our rule picks `(l, o)`. Because these letters are ASCII, character and byte\n",
+    "counts coincide here. The chart in the slides uses exactly these weighted totals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "low-check",
+   "metadata": {},
+   "source": [
+    "toy_corpus = [(\"low\", 5), (\"lower\", 2)]\n",
+    "vocab, merges, totals = train_bpe(toy_corpus, 2)\n",
+    "tokenizer = ByteBPETokenizer(vocab, merges)\n",
+    "for pair, new_id in merges:\n",
+    "    print(pair, \"->\", new_id, repr(vocab[new_id]))\n",
+    "print(\"Weighted token totals:\", totals)\n",
+    "print(\"Vocabulary size:\", len(vocab))\n",
+    "assert totals == [25, 18, 11]\n",
+    "assert merges == [((108, 111), 256), ((256, 119), 257)]\n",
+    "assert len(vocab) == 258"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e04",
+   "metadata": {},
+   "source": [
+    "## E04 · Encode unseen text · 5 minutes\n",
+    "\n",
+    "Use the **fixed** vocabulary and merge order learned above. Predict the token IDs for\n",
+    "`lowest`, then predict whether `你好🙂` can still be represented exactly.\n",
+    "\n",
+    "**Your predictions:** replace this sentence before running the check."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "heldout-check",
+   "metadata": {},
+   "source": [
+    "for text in [\"lowest\", \"你好🙂\", \"low low\", \"\", \"e\\u0301\"]:\n",
+    "    ids = tokenizer.encode(text)\n",
+    "    print(repr(text), ids, tokenizer.pieces(text))\n",
+    "    assert tokenizer.decode(ids) == text\n",
+    "assert tokenizer.encode(\"lowest\") == [257, 101, 115, 116]\n",
+    "assert len(tokenizer.encode(\"你好🙂\")) == 10\n",
+    "assert len(tokenizer.vocab) == 258  # Encoding did not add new entries."
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e04-check",
+   "metadata": {},
+   "source": [
+    "**Check:** `lowest` becomes `[low, e, s, t]`. The Chinese/emoji string has ten base-byte\n",
+    "tokens because it contains neither learned ASCII pair. It still round-trips exactly.\n",
+    "An empty string becomes an empty token list. Training learns the vocabulary; encoding\n",
+    "does not grow it.\n",
+    "\n",
+    "### Merge rank beats leftmost position\n",
+    "\n",
+    "If `(b, c)` was learned before `(a, b)`, encoding `abc` yields `[a, bc]`. A longest-prefix\n",
+    "lookup could instead choose `[ab, c]`, which is a different algorithm. Verify with a\n",
+    "training corpus that makes those ranks occur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "rank-check",
+   "metadata": {},
+   "source": [
+    "rank_vocab, rank_merges, _ = train_bpe([(\"bc\", 3), (\"ab\", 2)], 2)\n",
+    "rank_tokenizer = ByteBPETokenizer(rank_vocab, rank_merges)\n",
+    "print(\"Merge order:\", [rank_vocab[new_id] for _, new_id in rank_merges])\n",
+    "print(\"abc:\", rank_tokenizer.pieces(\"abc\"))\n",
+    "assert rank_tokenizer.pieces(\"abc\") == [b\"a\", b\"bc\"]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e05",
+   "metadata": {},
+   "source": [
+    "## E05 · Vocabulary size and held-out text · 8 minutes\n",
+    "\n",
+    "Train toy tokenizers with 0, 8, and 32 merges. Hold the evaluation text fixed and keep it\n",
+    "out of training. These small, synthetic corpora illustrate the method; they are not a\n",
+    "language benchmark. Frequencies are teaching weights, not measured usage statistics.\n",
+    "\n",
+    "For each language, report total tokens, UTF-8 bytes per token, and successful round trips.\n",
+    "Then repeat with **English-only** training. Which result changes, and why?\n",
+    "\n",
+    "**Your prediction about English-only training:** replace this sentence before running."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "comparison-data",
+   "metadata": {},
+   "source": [
+    "TRAIN_EN = [(\"the cat is on the mat\", 4), (\"the dog is in the room\", 3),\n",
+    "            (\"we study language models\", 3), (\"a model reads text\", 2)]\n",
+    "TRAIN_ZH = [(\"我们学习语言模型。\", 4), (\"语言模型读取文本。\", 3),\n",
+    "            (\"这是一门课程。\", 3), (\"今天学习新的知识。\", 2)]\n",
+    "HELD_OUT = {\n",
+    "    \"English\": [\"the cat reads text\", \"we study a new model\"],\n",
+    "    \"Chinese\": [\"我们学习新的模型。\", \"这是一门语言课程。\"],\n",
+    "}\n",
+    "training_texts = {text for text, _ in TRAIN_EN + TRAIN_ZH}\n",
+    "assert all(text not in training_texts for texts in HELD_OUT.values() for text in texts)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "comparison-metrics",
+   "metadata": {},
+   "source": [
+    "def measure(tokenizer, texts):\n",
+    "    total_bytes = sum(len(text.encode(\"utf-8\")) for text in texts)\n",
+    "    total_tokens = sum(len(tokenizer.encode(text)) for text in texts)\n",
+    "    roundtrip = all(tokenizer.decode(tokenizer.encode(text)) == text for text in texts)\n",
+    "    return {\"tokens\": total_tokens,\n",
+    "            \"bytes_per_token\": total_bytes / total_tokens if total_tokens else None,\n",
+    "            \"roundtrip\": roundtrip}\n",
+    "\n",
+    "\n",
+    "comparison_rows = []\n",
+    "for training_name, corpus in [(\"EN + ZH\", TRAIN_EN + TRAIN_ZH), (\"EN only\", TRAIN_EN)]:\n",
+    "    for budget in [0, 8, 32]:\n",
+    "        current_vocab, current_merges, _ = train_bpe(corpus, budget)\n",
+    "        current = ByteBPETokenizer(current_vocab, current_merges)\n",
+    "        for language, texts in HELD_OUT.items():\n",
+    "            metrics = measure(current, texts)\n",
+    "            assert metrics[\"roundtrip\"]\n",
+    "            row = {\"training\": training_name, \"budget\": budget,\n",
+    "                   \"learned\": len(current_merges), \"vocab\": len(current_vocab),\n",
+    "                   \"language\": language, **metrics}\n",
+    "            comparison_rows.append(row)\n",
+    "            print(training_name, \"merges:\", len(current_merges), language,\n",
+    "                  \"tokens:\", metrics[\"tokens\"],\n",
+    "                  \"bytes/token:\", round(metrics[\"bytes_per_token\"], 3))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e05-check",
+   "metadata": {},
+   "source": [
+    "**Check:** all inputs round-trip, including under English-only training. At zero merges,\n",
+    "bytes per token is exactly 1. English-only merges here cannot compress the Chinese\n",
+    "examples, whose UTF-8 bytes contain none of the learned ASCII pairs. Mixed training can\n",
+    "learn Chinese byte sequences. Inspect the measured counts instead of assuming equal\n",
+    "compression across languages.\n",
+    "\n",
+    "**Discussion:**\n",
+    "\n",
+    "- Does increasing the merge budget always help each language by the same amount?\n",
+    "- Why does lower token count not prove better model quality?\n",
+    "- What else must be held fixed to compare real model tokenizers fairly?\n",
+    "\n",
+    "At embedding width 1,024, vocabularies of 32,000 and 64,000 require 32,768,000 and\n",
+    "65,536,000 embedding entries respectively. These are illustrative parameter counts.\n",
+    "Fewer tokens may reduce sequence-processing work, but larger vocabulary tables cost\n",
+    "memory. We have not trained a language model or measured downstream accuracy here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "further",
+   "metadata": {},
+   "source": [
+    "## Further experiments\n",
+    "\n",
+    "The classroom core ends above. Enable only the experiment you want below. Model features\n",
+    "depend on the installed Ollama version and model; failed API calls report their actual\n",
+    "errors. Do not infer capabilities from a model family name alone.\n",
+    "\n",
+    "### Token log probabilities\n",
+    "\n",
+    "This recreates the local probability-inspection example from the previous notebook.\n",
+    "Ollama's current generate API accepts `logprobs` and `top_logprobs`. The returned\n",
+    "probability `exp(logprob)` is for a token conditioned on the prefix, **not** the probability\n",
+    "that the answer is factually correct. Top-k candidates need not sum to one. A token's\n",
+    "display text can be only part of a word; inspect the returned bytes if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "logprobs",
+   "metadata": {
+    "tags": [
+     "requires-ollama",
+     "optional"
+    ]
+   },
+   "source": [
+    "RUN_LOGPROBS = False\n",
+    "if RUN_LOGPROBS:\n",
+    "    probability_response = generate(\n",
+    "        \"Fudan University is located in which city? Answer with one word.\",\n",
+    "        max_tokens=20, logprobs=True, top_logprobs=5,\n",
+    "    )\n",
+    "    if probability_response:\n",
+    "        entries = probability_response.get(\"logprobs\", [])\n",
+    "        if not entries:\n",
+    "            print(\"No log probabilities returned; check runtime/model support.\")\n",
+    "        for entry in entries:\n",
+    "            print(repr(entry[\"token\"]), \"p =\", math.exp(entry[\"logprob\"]))\n",
+    "            for alternative in entry.get(\"top_logprobs\", []):\n",
+    "                print(\"  \", repr(alternative[\"token\"]),\n",
+    "                      math.exp(alternative[\"logprob\"]))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "thinking-intro",
+   "metadata": {},
+   "source": [
+    "### Thinking output and final answer\n",
+    "\n",
+    "For the Qwen3 models used here, `think=True` requests separate thinking output. Compare\n",
+    "it with the final `response`. The generated trace is not a guaranteed faithful account of\n",
+    "the model's internal computation. A short token budget may be exhausted before a final\n",
+    "answer appears; an empty final answer in that case does not mean the server failed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "thinking",
+   "metadata": {
+    "tags": [
+     "requires-ollama",
+     "optional"
+    ]
+   },
+   "source": [
+    "RUN_THINKING = False\n",
+    "if RUN_THINKING:\n",
+    "    thinking_response = generate(\"Which is larger, 9.11 or 9.9? Explain briefly.\",\n",
+    "                                 think=True, max_tokens=256)\n",
+    "    if thinking_response:\n",
+    "        print(\"Thinking:\", thinking_response.get(\"thinking\", \"[not returned]\"))\n",
+    "        print(\"Final answer:\", thinking_response.get(\"response\", \"\"))\n",
+    "        print(\"Stop reason:\", thinking_response.get(\"done_reason\"))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "vision-intro",
+   "metadata": {},
+   "source": [
+    "### Image understanding\n",
+    "\n",
+    "This is the notebook counterpart of the old image-question demo. Supply your own PNG\n",
+    "or JPEG and an **already installed vision-capable model**. The default Qwen3 text model\n",
+    "above cannot process images. For example, install a compatible `qwen3-vl` model outside\n",
+    "the notebook if you want to do this experiment; check its requirements first.\n",
+    "\n",
+    "The REST API takes base64 image data in `messages[].images`. For `/api/chat`, read\n",
+    "`message.content` rather than the `/api/generate` field `response`. Ask for visible facts\n",
+    "first, then identify an unsupported detail in the answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "vision-payload-definition",
+   "metadata": {
+    "tags": [
+     "definitions"
+    ]
+   },
+   "source": [
+    "def vision_payload(image_bytes, model):\n",
+    "    return {\n",
+    "        \"model\": model, \"stream\": False,\n",
+    "        \"messages\": [{\"role\": \"user\",\n",
+    "                      \"content\": \"Describe only what is visible in this image in two sentences.\",\n",
+    "                      \"images\": [base64.b64encode(image_bytes).decode(\"ascii\")]}],\n",
+    "        \"options\": {\"temperature\": 0, \"num_predict\": 128},\n",
+    "    }"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "vision",
+   "metadata": {
+    "tags": [
+     "requires-ollama",
+     "optional"
+    ]
+   },
+   "source": [
+    "RUN_VISION = False\n",
+    "VISION_MODEL = \"qwen3-vl:2b\"\n",
+    "IMAGE_PATH = Path(\"my-image.jpg\")  # Put your image beside your personal notebook.\n",
+    "if RUN_VISION and RUN_OLLAMA:\n",
+    "    installed = {m[\"name\"] for m in ollama_request(\"/api/tags\")[\"models\"]}\n",
+    "    if VISION_MODEL not in installed:\n",
+    "        print(\"Install a vision model first; no model was downloaded.\")\n",
+    "    elif not IMAGE_PATH.is_file():\n",
+    "        print(\"Set IMAGE_PATH to your own existing PNG or JPEG image.\")\n",
+    "    else:\n",
+    "        info = ollama_request(\"/api/show\", {\"model\": VISION_MODEL})\n",
+    "        if \"vision\" not in info.get(\"capabilities\", []):\n",
+    "            raise ValueError(\"The selected model does not report vision capability.\")\n",
+    "        response = ollama_request(\"/api/chat\", vision_payload(IMAGE_PATH.read_bytes(), VISION_MODEL))\n",
+    "        print(response[\"message\"][\"content\"])"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "existing-tokenizers",
+   "metadata": {},
+   "source": [
+    "### Compare named tokenizer encodings\n",
+    "\n",
+    "`tiktoken` is already in the course environment. Its first use of an encoding may download\n",
+    "that encoding's vocabulary; this optional cell therefore needs network access unless\n",
+    "already cached. `cl100k_base` and `o200k_base` are **encoding names**, not evidence about\n",
+    "which tokenizer an unverified model version uses.\n",
+    "\n",
+    "Inspect spaces, digits, Chinese, and emoji. Individual token byte strings may not decode\n",
+    "as standalone UTF-8. `encode_ordinary` treats text literally rather than interpreting\n",
+    "special-token spellings as control IDs. Record the package version and encoding name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "tiktoken-comparison",
+   "metadata": {
+    "tags": [
+     "optional",
+     "requires-network"
+    ]
+   },
+   "source": [
+    "RUN_TIKTOKEN = False\n",
+    "if RUN_TIKTOKEN:\n",
+    "    import importlib.metadata\n",
+    "    import tiktoken\n",
+    "\n",
+    "    print(\"tiktoken version:\", importlib.metadata.version(\"tiktoken\"))\n",
+    "    for encoding_name in [\"cl100k_base\", \"o200k_base\"]:\n",
+    "        encoding = tiktoken.get_encoding(encoding_name)\n",
+    "        print(\"\\nEncoding:\", encoding_name, \"vocabulary:\", encoding.n_vocab)\n",
+    "        for text in [\"hello hello\", \"你好，世界！\", \"2026-09-09\", \"🙂\", \"e\\u0301\"]:\n",
+    "            ids = encoding.encode_ordinary(text)\n",
+    "            pieces = [encoding.decode_single_token_bytes(index) for index in ids]\n",
+    "            assert encoding.decode(ids) == text\n",
+    "            print(repr(text), \"tokens:\", len(ids), \"IDs:\", ids, \"pieces:\", pieces)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "references",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "- [Fudan Spring Lecture 01](https://baojian.github.io/llm-26/slides/lecture-01-slides/):\n",
+    "  language ambiguity, camera reviews, translation, and the original Ollama demonstrations.\n",
+    "- [Stanford CS336 Spring 2026, Lecture 1](https://cs336.stanford.edu/lectures/?trace=lecture_01):\n",
+    "  tokenizer interfaces, byte baselines, BPE training/encoding, and resource tradeoffs.\n",
+    "- [Jurafsky and Martin, Words and Tokens](https://web.stanford.edu/~jurafsky/slp3/2.pdf):\n",
+    "  Sections 2.3–2.4 (August 2026 draft).\n",
+    "- [Sennrich, Haddow, and Birch (2016)](https://aclanthology.org/P16-1162/), Section 3.2;\n",
+    "  [Kudo and Richardson (2018)](https://aclanthology.org/P18-5009/) for further reading.\n",
+    "  PDF copies are in the course repository's `papers/` folder.\n",
+    "- [Python Unicode HOWTO](https://docs.python.org/3/howto/unicode.html).\n",
+    "- Ollama: [generate](https://docs.ollama.com/api/generate),\n",
+    "  [model list](https://docs.ollama.com/api/tags),\n",
+    "  [thinking](https://docs.ollama.com/capabilities/thinking),\n",
+    "  [vision](https://docs.ollama.com/capabilities/vision),\n",
+    "  [chat](https://docs.ollama.com/api/chat), and [usage metrics](https://docs.ollama.com/api/usage).\n",
+    "- [tiktoken](https://github.com/openai/tiktoken): named encodings and special-token handling.\n",
+    "\n",
+    "API examples checked against the linked documentation on September 8, 2026."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/slides/lecture-01/lecture.json
+++ b/slides/lecture-01/lecture.json
@@ -1,7 +1,7 @@
 {
   "number": "01",
-  "title": "Tokenization",
-  "subtitle": "How does text become model input?",
+  "title": "Introduction and Tokenization",
+  "subtitle": "Lecture 01 – Introduction to NLP & LLMs",
   "language": "en",
   "demo": "./demo.js",
   "notebook": "lecture-01-exercise.ipynb"

--- a/slides/lecture-01/slides.md
+++ b/slides/lecture-01/slides.md
@@ -1,30 +1,327 @@
 <!-- .slide: class="title-slide" id="title" -->
 
-<p class="eyebrow">CS40008.01 · Lecture 01</p>
+<p class="eyebrow">CS40008.01</p>
 
-# Tokenization
+# Introduction and Tokenization
 
-<p class="subtitle">How does text become model input?</p>
+<p class="subtitle">Lecture 01 – Introduction to NLP &amp; LLMs</p>
 
-<p class="byline">Baojian Zhou<br>Fudan University · Fall 2026</p>
+<p class="byline">Baojian Zhou<br>School of Data Science<br>Fudan University<br>September 9, 2026</p>
 
 Note:
 Ask students how they think a model represents a Chinese sentence.
 
 ---
 
-<!-- .slide: id="representation" -->
+<!-- .slide: class="outline-slide" id="outline-overview" -->
 
-## Text representation
+## Outline
 
-A tokenizer maps text to a sequence of token IDs.
-
-The model reads those IDs through an embedding table.
-
-> The tokenizer defines which pieces of text share a vocabulary entry.
+<ul class="outline-topics">
+<li aria-current="step">Course Overview</li>
+<li>Development of NLP &amp; LLMs</li>
+<li>Basics for Text Preprocessing</li>
+<li>Text Tokenization</li>
+</ul>
 
 Note:
-Distinguish a tokenizer from the model that uses it. A token ID has meaning only within its tokenizer's vocabulary.
+Period 1, minutes 0–25: course overview. Read the four topics once. There are three 45-minute teaching periods, with breaks outside the 135 minutes. Return to this outline at each transition. Source: the four-part structure in Fudan Spring Lecture 01, https://baojian.github.io/llm-26/slides/lecture-01-slides/.
+
+---
+
+<!-- .slide: id="goals" -->
+
+## Today’s question
+
+How does an LLM application turn our text into something a model can predict?
+
+- Call a local model and examine its answers.
+- Explain the difference between characters, bytes, and tokens.
+- Train a small BPE tokenizer and test it on unseen text.
+
+Note:
+Ask for one hypothesis before giving the vocabulary. The notebook follows the same sequence; the core tokenizer needs only Python’s standard library.
+
+---
+
+<!-- .slide: id="survey" -->
+
+## The LLM apps you use
+
+Which apps do you use most in everyday life?
+
+Choose **at most two** in the [first-lecture survey](https://github.com/baojian/llm-26-fall/issues/6).
+
+Submit your response through one pull request, following the issue’s guide.
+
+> What do you usually ask these apps to do?
+
+Note:
+Take two or three examples aloud. Explain that an app may combine a model, search, tools, and an interface. Introduce the GitHub workflow here; students can finish the PR after class. Do not spend the period debugging individual accounts.
+
+---
+
+<!-- .slide: id="app-model-tokenizer" -->
+
+## App, model, tokenizer
+
+| Component | In our local experiment |
+| :--- | :--- |
+| Interface | A Jupyter notebook |
+| Model runtime | Ollama |
+| Model | Qwen3, using an installed model tag |
+| Tokenizer | The vocabulary and rules paired with that model |
+
+Our toy tokenizer is a separate learning exercise.
+
+Note:
+Ollama serves the model; it is not itself the language model. The tokenizer we train today is not compatible with Qwen’s existing embedding table. A model tag identifies a packaged model; record its digest because tags can change. API source: https://docs.ollama.com/api/tags.
+
+---
+
+<!-- .slide: id="natural-language" -->
+
+## Natural language needs context
+
+> A man saw a boy with a telescope.
+
+Who had the telescope?
+
+> 冬天，能穿多少穿多少。<br>夏天，能穿多少穿多少。
+
+The same words can support different interpretations.
+
+Note:
+Invite both attachment readings of the English sentence. In Chinese, contrast wearing as much as possible in winter with as little as possible in summer. These are ambiguity examples from Fudan Spring Lecture 01; context resolves meanings, while tokenization only chooses a representation.
+
+---
+
+<!-- .slide: id="nlp-tasks" -->
+
+## Language tasks in one notebook
+
+| Task | Input → output |
+| :--- | :--- |
+| Sentiment | Camera review → label and reason |
+| Translation | Chinese paragraph → English text |
+| Generation | Instructions → a short course welcome |
+| Image understanding | Image + question → description |
+
+Run text examples together; explore vision after class.
+
+Note:
+Preserve the application examples from the previous lecture, but execute their Ollama calls in Jupyter. Vision needs a separate compatible model. Do not spend class downloading it. Source: Fudan Spring Lecture 01, sentiment, translation, generation, and image-understanding examples.
+
+---
+
+<!-- .slide: class="exercise" id="exercise-01" -->
+
+## Does “light” mean positive?
+
+<p class="exercise-meta">Exercise E01 · 5 minutes · Notebook E01</p>
+
+1. “Nice and compact to carry!”
+2. “The camera is small and light; I avoid carrying bulky cameras.”
+3. “The camera feels flimsy, plastic, and very light.”
+
+Predict the labels, then compare them with Ollama’s responses.
+
+<div class="answer fragment"><p>Expected: positive, positive, negative. The surrounding words change the meaning of “light.”</p></div>
+
+Note:
+Allow one minute to label individually, two to run notebook E01, and two to compare. These are shortened versions of the camera reviews in the previous Fudan lecture; the notebook keeps the full review text. The expected labels are human judgments for these examples, not guaranteed model outputs. Discuss any disagreement.
+
+---
+
+<!-- .slide: id="notebook-demo" -->
+
+## A local model call
+
+Open **Notebook** and run the Ollama section.
+
+- Send a prompt; inspect the returned text.
+- Keep the model and generation settings fixed.
+- Change the task to translation or generation.
+
+Record an error or an unsupported claim, even when the answer sounds fluent.
+
+Note:
+The notebook uses POST /api/generate with stream=false and think=false, then reads response. Ollama is installed separately from uv; the core tokenizer cells still run if it is unavailable. The instructor can run the demonstration on the classroom computer; students without a local model can work from their predictions. Source: https://docs.ollama.com/api/generate.
+
+---
+
+<!-- .slide: id="course-work" -->
+
+## What we will build
+
+Text representation → language models → Transformers → LLM applications
+
+| Assessment | Weight |
+| :--- | ---: |
+| Quizzes | 10% |
+| Assignments | 45% |
+| Individual course project | 45% |
+
+A1 is released in **Week 2**. See the [course page](../../index.html#assessment) for details.
+
+Note:
+Distinguish today’s ungraded practice from graded assignments. The course website is the source of current assessment rules. Do not import the Stanford workload or the previous semester’s deadlines. Connect small reproducible experiments to the individual project.
+
+---
+
+<!-- .slide: class="outline-slide" id="outline-development" -->
+
+## Outline
+
+<ul class="outline-topics">
+<li>Course Overview</li>
+<li aria-current="step">Development of NLP &amp; LLMs</li>
+<li>Basics for Text Preprocessing</li>
+<li>Text Tokenization</li>
+</ul>
+
+Note:
+Period 1, minutes 25–45. Use about six minutes for the historical sketches and fourteen for prediction, training, and resource constraints.
+
+---
+
+<!-- .slide: id="development" -->
+
+## Three approaches to language tasks
+
+| Approach | Sentiment example |
+| :--- | :--- |
+| Rules | Count words such as “good” and “bad” |
+| Statistical learning | Learn feature weights from labeled reviews |
+| Neural language models | Learn representations; adapt or prompt the model |
+
+These approaches can coexist inside an application.
+
+Note:
+This is a conceptual progression, not a claim that one method disappeared when another arrived. Revisit “light”: a bag of isolated sentiment words loses context. Background: Fudan Spring Lecture 01, development of NLP; Bengio et al. 2003, https://www.jmlr.org/papers/v3/bengio03a.html.
+
+---
+
+<!-- .slide: id="milestones" -->
+
+## Selected milestones
+
+| Work | Idea to remember |
+| :--- | :--- |
+| Neural language model, 2003 | Learn word representations and probabilities together |
+| Transformer, 2017 | Attention-based sequence modeling |
+| GPT-3, 2020 | Specify tasks using examples in the prompt |
+
+We will study the mechanisms behind these ideas.
+
+Note:
+These are selected landmarks rather than a complete history. Bengio et al., A Neural Probabilistic Language Model: https://www.jmlr.org/papers/v3/bengio03a.html. Vaswani et al., Attention Is All You Need: https://arxiv.org/abs/1706.03762. Brown et al., Language Models are Few-Shot Learners: https://arxiv.org/abs/2005.14165. Avoid equating prompting with training: GPT-3 few-shot evaluation did not update model weights.
+
+---
+
+<!-- .slide: id="next-token" -->
+
+## Next-token prediction
+
+Prompt: “Fudan University is located in …”
+
+The model assigns a probability to each possible **next token**.
+
+$$p_\theta(t_1,\ldots,t_L)=\prod_{i=1}^{L}p_\theta(t_i\mid t_{<i})$$
+
+Choose a token, append it, and repeat.
+
+Note:
+This is an autoregressive factorization, not an assumption that tokens are independent. “Shanghai” is an intended answer, but do not claim it is one token without inspecting the model tokenizer. The notebook’s further experiments inspect actual token log probabilities when supported. Background: CS336 Lecture 1, https://cs336.stanford.edu/lectures/?trace=lecture_01.
+
+---
+
+<!-- .slide: id="prediction-limits" -->
+
+## Prediction and correctness
+
+A plausible continuation can contain a factual error.
+
+- A token probability measures a continuation under the model.
+- A generated explanation is another model output.
+- A correct-looking example does not establish task accuracy.
+
+Use a separate set of examples with expected answers.
+
+Note:
+Ask what evidence would support a claim that sentiment classification improved: held-out labeled reviews, a fixed prompt, a specified metric, and comparable settings. Do not describe a self-reported confidence score or thinking trace as calibrated correctness. The optional log-probability experiment makes this distinction concrete.
+
+---
+
+<!-- .slide: id="training-pipeline" -->
+
+## Building a language model
+
+| Stage | A decision we must make |
+| :--- | :--- |
+| Data | Which text belongs in training and evaluation? |
+| Tokenizer | Which pieces become vocabulary entries? |
+| Model and training | Which architecture, objective, and compute budget? |
+| Evaluation | Which tasks and failure cases matter? |
+
+Today we build the tokenizer.
+
+Note:
+Adapted from CS336 Spring 2026 Lecture 1’s learn-by-building motivation and pipeline, https://cs336.stanford.edu/lectures/?trace=lecture_01. Explain that tokenizer training learns a vocabulary, while model training learns numerical parameters. Keep held-out text out of both training stages when measuring generalization.
+
+---
+
+<!-- .slide: id="resource-budget" -->
+
+## Working within a compute budget
+
+More data, a larger model, and longer sequences all use resources.
+
+For today’s tokenizer, we can measure:
+
+- vocabulary size;
+- tokens needed for the same text;
+- whether decoding recovers the original input.
+
+We can test these choices on a laptop.
+
+Note:
+Source: CS336 Lecture 1’s emphasis on resource constraints and empirical experiments. Do not claim compression alone improves model quality. Pause for the first break after this slide. Next period begins with the actual representation of text.
+
+---
+
+<!-- .slide: class="outline-slide" id="outline-preprocessing" -->
+
+## Outline
+
+<ul class="outline-topics">
+<li>Course Overview</li>
+<li>Development of NLP &amp; LLMs</li>
+<li aria-current="step">Basics for Text Preprocessing</li>
+<li>Text Tokenization</li>
+</ul>
+
+Note:
+Period 2, minutes 0–20: Unicode, UTF-8, and preserving the input. Python basics are prerequisites; this is not a full regex tutorial.
+
+---
+
+<!-- .slide: id="preprocessing" -->
+
+## Preserve the text you intend to model
+
+```python
+text = "Hello,  世界!\n🙂"
+print(repr(text))
+print(repr(text.lower().strip()))
+```
+
+Spaces, punctuation, capitalization, and line breaks can carry information.
+
+Choose normalization deliberately and document it.
+
+Note:
+There are two spaces after the comma and a newline before the emoji. Lowercasing changes H to h; strip only removes whitespace at the ends, not the internal spaces or newline. A lossless tokenizer should round-trip its input. A normalizing tokenizer may only recover the normalized input. Python Unicode HOWTO: https://docs.python.org/3/howto/unicode.html.
 
 ---
 
@@ -100,17 +397,103 @@ For a decomposed accent, compare the precomposed é with e followed by a combini
 
 ---
 
-<!-- .slide: class="section-slide" id="bpe" -->
+<!-- .slide: class="exercise" id="exercise-02" -->
 
-<p class="eyebrow">A small algorithm</p>
+## Same appearance, different strings
+
+<p class="exercise-meta">Exercise E02 · 3 minutes · Notebook E02</p>
+
+Compare <code>"é"</code>, <code>"e\u0301"</code>, and <code>"你好🙂"</code>.
+
+Predict the code-point and UTF-8 byte counts. Check the round trip.
+
+<div class="answer fragment"><p>Counts: 1 / 2, 2 / 3, and 3 / 10.<br>The two accented strings look alike but are not equal.</p></div>
+
+Note:
+The second displayed string contains e followed by U+0301 COMBINING ACUTE ACCENT. Python len counts two code points; UTF-8 uses three bytes. NFC normalization makes the two accented strings equal but changes the original code-point sequence. Let students predict first, then run E02.
+
+---
+
+<!-- .slide: id="byte-roundtrip" -->
+
+## A complete UTF-8 round trip
+
+```python
+text = "你好🙂"
+ids = list(text.encode("utf-8"))
+restored = bytes(ids).decode("utf-8")
+assert restored == text
+```
+
+A token may contain only part of a UTF-8 character.
+
+Join the token bytes **before** decoding the full text.
+
+Note:
+A byte has 256 possible values. A single byte from 你 is not valid UTF-8 by itself; strict decoding should fail instead of silently replacing it. The notebook demonstrates that failure and the successful full round trip. Source: Python Unicode HOWTO and CS336 Lecture 1 byte tokenizer.
+
+---
+
+<!-- .slide: class="outline-slide" id="outline-tokenization" -->
+
+## Outline
+
+<ul class="outline-topics">
+<li>Course Overview</li>
+<li>Development of NLP &amp; LLMs</li>
+<li>Basics for Text Preprocessing</li>
+<li aria-current="step">Text Tokenization</li>
+</ul>
+
+Note:
+Period 2, minutes 20–45: representation choices and the first two merges. Reserve four minutes for E03. Continue with encoding and experiments after the break.
+
+---
+
+<!-- .slide: id="representation" -->
+
+## Text representation
+
+A tokenizer maps text to a sequence of token IDs.
+
+The model reads those IDs through an embedding table.
+
+> The tokenizer defines which pieces of text share a vocabulary entry.
+
+Note:
+Distinguish a tokenizer from the model that uses it. A token ID has meaning only within its tokenizer's vocabulary.
+
+---
+
+<!-- .slide: id="tokenizer-choices" -->
+
+## Choosing the basic unit
+
+| Unit | Benefit | Limitation |
+| :--- | :--- | :--- |
+| Word | Familiar units | Unseen words; segmentation choices |
+| Code point | Simple character representation | Large alphabet; rare characters |
+| Byte | Only 256 base entries | Long sequences |
+| Learned subword | Frequent pieces become short | Depends on training data and rules |
+
+Note:
+Adapted from CS336 Lecture 1 character, byte, word, and BPE comparisons. A learned character vocabulary can have unknown characters; directly using Unicode scalar values avoids that but yields a sparse ID space. Chinese words are not reliably separated by spaces. BPE is one way to learn subwords, not the only algorithm.
+
+---
+
+<!-- .slide: id="bpe" -->
 
 ## Byte pair encoding
 
-The training procedure repeatedly merges a frequent adjacent pair.
+1. Begin with small units: bytes in our implementation.
+2. Count adjacent token pairs in the training corpus.
+3. Add the most frequent pair as one new vocabulary entry.
+4. Replace its occurrences and repeat.
+
+Save the **ordered merges** and the **vocabulary**.
 
 Note:
-Introduce the distinction between learning merges and applying an existing merge list.
-The next example begins with characters to keep the arithmetic visible.
+Adapted from CS336 Lecture 1 and Sennrich et al. 2016 Section 3.2, ../../papers/sennrich-2016-subword-units.pdf. Our byte vocabulary differs from the character-based, word-boundary-aware algorithm in the paper. No merges cross our input-sequence boundaries. Stop when the merge budget is reached or no pair remains.
 
 ---
 
@@ -137,26 +520,41 @@ Different tie-breaking choices can lead to different learned merges.
 
 ---
 
-<!-- .slide: class="exercise" id="exercise-01" -->
+<!-- .slide: id="pair-counts" -->
 
-<p class="exercise-meta">Exercise E01 · 3 minutes · Notebook E01</p>
+## Count the pairs, including frequency
 
-## Which pair merges first?
+| Pair | In `low` × 5 | In `lower` × 2 | Total |
+| :--- | ---: | ---: | ---: |
+| `l o` | 5 | 2 | 7 |
+| `o w` | 5 | 2 | 7 |
+| `w e` | 0 | 2 | 2 |
+| `e r` | 0 | 2 | 2 |
+
+Tie rule: choose the smallest pair of token IDs.
+
+Note:
+ASCII base IDs are l=108, o=111, w=119, e=101, r=114. The maximum count is seven; (108,111) wins over (111,119). Break only the tied maximum, not all pairs. Deterministic ties make the lesson reproducible; production implementations may choose a different rule.
+
+---
+
+<!-- .slide: class="exercise" id="exercise-03" -->
+
+## Counting overlaps; applying a merge
+
+<p class="exercise-meta">Exercise E03 · 4 minutes · Notebook E03</p>
 
 | Initial sequence | Frequency |
 | :--- | ---: |
 | `a a a b` | 2 |
 | `a b` | 1 |
 
-Count every adjacent pair, including overlapping occurrences.
+Which pair wins? How many tokens does one merge remove?
 
-<div class="answer fragment">
-<p><code>a a</code> occurs 4 times. <code>a b</code> occurs 3 times.</p>
-</div>
+<div class="answer fragment"><p><code>a a</code>: 4 occurrences; <code>a b</code>: 3.<br>Replace left to right: <code>aa a b</code>. Total tokens: 10 → 8.</p></div>
 
 Note:
-Ask students to explain why a a is counted twice in a a a b.
-Pair frequency can include overlaps. Applying the merge left to right replaces non-overlapping occurrences.
+One minute count, one minute propose replacements, two minutes check in the notebook. Pair counts include overlapping aa positions, but replacements cannot share an a. The winning count of four does not mean four replacements: only two across the weighted corpus. Expected E03 output is 10 then 8.
 
 ---
 
@@ -193,6 +591,127 @@ The chart loads automatically from a local Plotly specification. It plots the ch
 
 ---
 
+<!-- .slide: id="learned-vocabulary" -->
+
+## The learned vocabulary
+
+| Token ID | Stored bytes | Learned from |
+| :--- | :--- | :--- |
+| 0–255 | Each possible byte | Initial vocabulary |
+| 256 | `b"lo"` | `(108, 111)` |
+| 257 | `b"low"` | `(256, 119)` |
+
+After two merges: **258 entries**.
+
+The model would need an embedding for each entry.
+
+Note:
+The ASCII toy example is also a byte example, since each character here is one byte. Decoding uses this mapping, not the decimal digits in the token ID. IDs are specific to this tokenizer. Do not substitute these IDs into a pretrained Qwen model. Pause for the second break after this slide.
+
+---
+
+<!-- .slide: class="outline-slide" id="outline-tokenization-period-3" -->
+
+## Outline
+
+<ul class="outline-topics">
+<li>Course Overview</li>
+<li>Development of NLP &amp; LLMs</li>
+<li>Basics for Text Preprocessing</li>
+<li aria-current="step">Text Tokenization</li>
+</ul>
+
+Note:
+Period 3, minutes 0–20: encoding and boundaries. Minutes 20–40: vocabulary tradeoffs and E05. Final five minutes: exit questions and reading.
+
+---
+
+<!-- .slide: id="training-encoding" -->
+
+## Training and encoding
+
+| Training | Encoding a new input |
+| :--- | :--- |
+| Count pairs in a training corpus | Begin with the input’s bytes |
+| Learn the next merge | Apply the saved merges in order |
+| Extend the vocabulary | Keep the vocabulary fixed |
+
+Encoding a new prompt does **not** retrain the tokenizer.
+
+Note:
+Source: CS336 Lecture 1 BPETokenizer and train_bpe. Our simple implementation scans the whole sequence once per learned merge. Production code uses more efficient structures and may restrict merges with a pre-tokenizer. The conceptual distinction is essential for E04.
+
+---
+
+<!-- .slide: class="exercise" id="exercise-04" -->
+
+## Encode a word we did not train on
+
+<p class="exercise-meta">Exercise E04 · 5 minutes · Notebook E04</p>
+
+Saved merges: **`l o` → `lo`**, then **`lo w` → `low`**.
+
+Encode <code>"lowest"</code>. Then try <code>"你好🙂"</code>.
+
+<div class="answer fragment"><p><code>lowest</code> → <code>[257, 101, 115, 116]</code>.<br>Chinese and emoji still round-trip through the base bytes.</p></div>
+
+Note:
+Two minutes trace lowest; three minutes run and inspect both examples. The pieces are low, e, s, t. The Chinese/emoji example has ten byte tokens here because neither learned ASCII pair occurs. No unknown token is needed for a valid UTF-8 string when all 256 base bytes are retained.
+
+---
+
+<!-- .slide: id="merge-order" -->
+
+## Why the merge order matters
+
+Suppose training learned:
+
+1. `b c` → `bc`
+2. `a b` → `ab`
+
+Encoding <code>"abc"</code> gives <code>[a, bc]</code>.
+
+It does not choose <code>[ab, c]</code> just because <code>ab</code> starts earlier.
+
+Note:
+An independently checkable example: training strings bc repeated three times and ab repeated twice learn bc before ab. At inference the earlier-ranked available merge wins. The notebook constructs this tokenizer and checks its output. Greedy longest-prefix matching is not a general substitute for BPE merge ranks.
+
+---
+
+<!-- .slide: id="boundaries" -->
+
+## Where merges are allowed
+
+Our toy corpus stores each string as a separate sequence.
+
+Production tokenizers may first separate text using rules for spaces, letters, numbers, or punctuation.
+
+> These boundaries can change the tokens, even when two implementations both use BPE.
+
+Keep boundary rules fixed when comparing results.
+
+Note:
+Source: CS336 Lecture 1 notes on pre-tokenization and https://github.com/openai/tiktoken. Our learner has no within-string pre-tokenizer: it can learn pieces that include spaces, and it never merges across input strings. The toy low/lower table treats words as separate sequences for transparent counting. Do not describe that as the full production pipeline.
+
+---
+
+<!-- .slide: id="special-tokens" -->
+
+## Text and control tokens
+
+Chat systems also need to represent roles and message boundaries.
+
+- Ordinary text is encoded using the text vocabulary.
+- Special tokens can have reserved IDs and defined roles.
+- The model’s chat template specifies the expected structure.
+
+Typing a special token’s spelling is not always equivalent to inserting its ID.
+
+Note:
+Source: CS336 Lecture 1 special-token discussion and tiktoken README, https://github.com/openai/tiktoken. Our toy BPE only handles ordinary text. Do not invent Qwen chat-token IDs. The optional tiktoken cell uses encode_ordinary so user text is treated literally, including strings that resemble special tokens.
+
+---
+
 <!-- .slide: id="equation" -->
 
 ## Average sequence length
@@ -212,17 +731,126 @@ This is an average per text, so document length affects it. Explain why a compar
 
 ---
 
-<!-- .slide: class="references" id="references" -->
+<!-- .slide: id="vocabulary-cost" -->
 
-## References
+## Vocabulary size has a cost
 
-- [Jurafsky and Martin, *Words and Tokens*](https://web.stanford.edu/~jurafsky/slp3/2.pdf)<br>Read Sections 2.3–2.4: Unicode and BPE (August 2026 draft).
+An embedding table with vocabulary size $V$ and width $d$ has $Vd$ entries.
 
-- <a href="../../papers/sennrich-2016-subword-units.pdf" target="_blank" rel="noopener noreferrer">Sennrich, Haddow, and Birch (2016)</a><br>Read Section 3.2 for the BPE-based subword method.
+| Toy configuration, $d=1{,}024$ | Embedding entries |
+| :--- | ---: |
+| $V=32{,}000$ | 32,768,000 |
+| $V=64{,}000$ | 65,536,000 |
 
-- <a href="../../papers/kudo-2018-sentencepiece.pdf" target="_blank" rel="noopener noreferrer">Kudo and Richardson (2018), SentencePiece</a><br>Further reading on language-independent tokenization.
-
-- [Python Unicode HOWTO](https://docs.python.org/3/howto/unicode.html)<br>Review Unicode strings and UTF-8 encoding.
+A larger vocabulary may shorten sequences, but increases this table.
 
 Note:
-The notebook is available through the Notebook link at the top of the page.
+These are calculated configurations, not measurements of a named model. Values are parameters, not bytes; storage depends on dtype and optimizer state. An untied output head would have additional parameters. Source: CS336 Lecture 1 vocabulary/compression tradeoff.
+
+---
+
+<!-- .slide: id="sequence-cost" -->
+
+## Sequence length also has a cost
+
+For full self-attention, each position can interact with other positions.
+
+$$1{,}000^2=1{,}000{,}000 \qquad 2{,}000^2=4{,}000{,}000$$
+
+Doubling length gives four times as many position pairs.
+
+This illustrates attention during training or prompt processing; total runtime depends on the implementation.
+
+Note:
+Toy count of all pairs. Causal attention masks future positions, but its pair count still grows quadratically. Efficient kernels need not materialize a full attention matrix. Cached generation has different per-step behavior, so do not say all inference costs scale as L squared. Source: Vaswani et al. 2017 Section 4, https://arxiv.org/abs/1706.03762.
+
+---
+
+<!-- .slide: class="exercise" id="exercise-05" -->
+
+## Test on held-out English and Chinese
+
+<p class="exercise-meta">Exercise E05 · 8 minutes · Notebook E05</p>
+
+Train toy tokenizers with **0, 8, and 32 merges**.
+
+Use the same held-out sentences each time. Report tokens and UTF-8 bytes per token separately for English and Chinese.
+
+<div class="answer fragment"><p>Every input must round-trip. Compression depends on the corpus; a smaller token count alone does not establish a better language model.</p></div>
+
+Note:
+Two minutes inspect the training/held-out split, three minutes run the experiment, three minutes interpret. The notebook supplies small synthetic teaching corpora and an English-only training comparison. Record the actual number of learned merges, which can be below the budget if no pair remains. Ratios aggregate bytes and tokens within each language, not across an imbalanced mix.
+
+---
+
+<!-- .slide: id="heldout-results" -->
+
+## Chinese text after different training
+
+<div class="plot" data-plotly="assets/heldout-chinese.json" role="img" aria-label="On the same held-out Chinese text, mixed training reduces token counts from 54 to 48 to 35 at zero, eight, and thirty-two merges. English-only training leaves the count at 54."></div>
+
+<p class="caption">Two fixed Chinese sentences · 54 UTF-8 bytes · Toy corpora from Notebook E05.</p>
+
+Note:
+These values are calculated with the exact training and held-out strings in notebook E05. With mixed English/Chinese training, counts are 54, 48, and 35; English-only training gives 54 throughout. English-only merges contain ASCII bytes that never occur in these Chinese strings. This small controlled demonstration is not a benchmark of real model tokenizers or language quality. Ask students to connect the plot to their own printed results.
+
+---
+
+<!-- .slide: id="comparison" -->
+
+## What belongs in a tokenizer comparison?
+
+| Keep fixed | Report |
+| :--- | :--- |
+| Input strings and normalization | Vocabulary and implementation |
+| Training and held-out split | Token count by language |
+| Treatment of spaces and boundaries | UTF-8 bytes per token |
+| Ordinary versus special tokens | Exact round-trip results |
+
+Measure downstream model quality separately.
+
+Note:
+The notebook also offers an optional comparison of the named cl100k_base and o200k_base encodings. Those are encoding names, not verified tokenizer identities for every commercial model. No unsupported claims about DeepSeek, Kimi, GLM, or Qwen versions belong in this lesson.
+
+---
+
+<!-- .slide: id="exit-questions" -->
+
+## Before you leave
+
+1. Why can one visible symbol require several tokens?
+2. What changes during BPE training, and what stays fixed during encoding?
+3. Does a shorter token sequence prove the model is more accurate?
+
+Next: probabilities over token sequences and a first language-model baseline.
+
+Note:
+Use the final five minutes, including readings. Expected: visible symbols may have multiple code points and bytes; tokenizer vocabulary determines grouping. Training learns merges/vocabulary; encoding keeps them fixed. Compression alone gives no evidence about model accuracy. Ask students to finish any notebook discussion questions and the survey after class.
+
+---
+
+<!-- .slide: class="references" id="lecture-sources" -->
+
+## Lecture sources and notebook extensions
+
+- [Fudan Spring Lecture 01](https://baojian.github.io/llm-26/slides/lecture-01-slides/)<br>Language examples, applications, and the four-part outline.
+- [Stanford CS336, Spring 2026, Lecture 1](https://cs336.stanford.edu/lectures/?trace=lecture_01)<br>Building language models, tokenizer baselines, and BPE.
+- [Ollama API](https://docs.ollama.com/api/generate)<br>Notebook extensions: log probabilities, thinking, and vision.
+
+The notebook contains the executable local-model demonstrations.
+
+Note:
+These sources support this adapted Fudan lecture. Stanford’s full lecture sequence and assignments are not requirements. The text experiments are core; the heavier extensions are available for interested students.
+
+---
+
+<!-- .slide: class="references" id="references" -->
+
+## Readings for Lecture 01
+
+- [Jurafsky and Martin, *Words and Tokens*](https://web.stanford.edu/~jurafsky/slp3/2.pdf)<br>Sections 2.3–2.4: Unicode and BPE (August 2026 draft).
+- <a href="../../papers/sennrich-2016-subword-units.pdf" target="_blank" rel="noopener noreferrer">Sennrich, Haddow, and Birch (2016)</a><br>Section 3.2: BPE for subword segmentation.
+- <a href="../../papers/kudo-2018-sentencepiece.pdf" target="_blank" rel="noopener noreferrer">Kudo and Richardson (2018), SentencePiece</a><br>Further reading on language-independent tokenization.
+
+Note:
+Read the textbook sections first, then trace the BPE example in Sennrich et al. Compare its word-boundary convention with our byte-based teaching implementation. SentencePiece is further reading, not an additional required implementation. Notebook references also link the Python Unicode HOWTO.

--- a/slides/lecture-01/teaching-plan.md
+++ b/slides/lecture-01/teaching-plan.md
@@ -1,0 +1,73 @@
+# Lecture 01: Introduction and Tokenization
+
+September 9, 2026 · CS40008.01 · Three 45-minute teaching periods
+
+## Central question
+
+How does an LLM application turn our text into something a model can predict?
+
+By the end, students should be able to call a local model, distinguish code
+points from bytes and tokens, trace BPE training and encoding, and compare
+tokenizers on held-out text without confusing compression with model quality.
+
+## Classroom plan
+
+| Period | Minutes within the period | Topic and activity |
+| --- | --- | --- |
+| 1 | 0–25 | Course overview, app survey, language ambiguity, E01: sentiment with Ollama |
+| 1 | 25–45 | Development of NLP and LLMs; next-token prediction and the training pipeline |
+| 2 | 0–20 | Text preprocessing, Unicode, UTF-8, E02: count and round-trip |
+| 2 | 20–45 | Tokenization choices, BPE training, E03: overlapping pairs and merge counts |
+| 3 | 0–20 | Fixed merge order, E04: encode unseen text, boundaries and special tokens |
+| 3 | 20–40 | Vocabulary tradeoffs, E05: held-out English and Chinese comparison |
+| 3 | 40–45 | Exit questions and readings |
+
+Breaks fall between periods and are outside these 135 teaching minutes. Repeat
+the four-topic outline at each section transition, with only the current topic
+in bold black. Repeat the tokenization outline after the second break.
+
+The five timed exercises total 25 minutes (5, 3, 4, 5, and 8 minutes).
+Students predict first, run the matching notebook section, then explain one
+observation. These are ungraded classroom practice. Use the course website for
+assessment rules and dates; A1 is released in Week 2.
+
+## Source map
+
+- [Fudan Spring Lecture 01](https://baojian.github.io/llm-26/slides/lecture-01-slides/):
+  the four-part outline, natural-language ambiguity, sentiment examples,
+  translation and generation demonstrations, and the motivation for subwords.
+- [Stanford CS336 Spring 2026, Lecture 1](https://cs336.stanford.edu/lectures/?trace=lecture_01):
+  learning by building, resource tradeoffs, the tokenizer interface, character
+  and byte baselines, BPE training versus encoding, and compression measurement.
+  The local source used for comparison is `lecture_01.py` in the instructor's
+  `stanford-cs336-lectures` checkout. Stanford's assessment rules do not apply.
+- [Sennrich et al. (2016), Section 3.2](../../papers/sennrich-2016-subword-units.pdf):
+  BPE-based subword segmentation. Our implementation begins with all 256 bytes;
+  the paper's character vocabulary and word-boundary convention differ.
+- [Ollama API](https://docs.ollama.com/api/generate): executable versions of the
+  previous browser demos. The notebook uses the REST API from Python's standard
+  library, so no additional Python package is required.
+
+## Notebook and preparation
+
+Use `lecture-01-exercise.ipynb` for executable work. The classroom core includes
+short text calls, Unicode, and a self-contained byte BPE implementation. The
+tokenization work runs without Ollama or network access. Ollama is a separate
+application: install it, start it, and fetch `qwen3:0.6b` before class. Model calls
+are short, but runtime depends on the classroom machine.
+
+Log probabilities, thinking output, image understanding, and a comparison with
+named `tiktoken` encodings are further notebook experiments. They are opt-in and
+are not required to complete the 135-minute lesson. Vision requires a suitable
+model and a student-provided image; no large model is downloaded by a cell.
+
+The toy corpus is `low` × 5 and `lower` × 2. The first two merges are `l o` and
+`lo w`, producing weighted token totals 25, 18, and 11. Pair ties use ascending
+token-ID pairs. Count overlapping pairs, but replace non-overlapping occurrences
+left to right. Each training string is a separate sequence, so no merge crosses
+a document boundary. The notebook deliberately omits production pre-tokenizers
+and chat-template processing and explains those limitations.
+
+The launcher preserves existing notebook answers. To receive a revised handout,
+rename the existing personal notebook in JupyterLab, then click **Notebook**
+again to create a fresh copy. Keep the renamed copy for your previous work.

--- a/slides/shared/theme.css
+++ b/slides/shared/theme.css
@@ -19,7 +19,7 @@ html, body { background: var(--r-background-color); }
 body { margin: 0; font-family: var(--r-main-font); color: var(--r-main-color); }
 .reveal { font-family: var(--r-main-font); font-size: 30px; font-weight: 400; line-height: 1.38; }
 .reveal .slides { text-align: left; }
-.reveal .slides > section { height: 720px; padding: 54px 64px 58px; box-sizing: border-box; }
+.reveal .slides > section { height: 720px; padding: 20px 64px 58px; box-sizing: border-box; }
 .reveal h1, .reveal h2, .reveal h3 { color: var(--r-heading-color); font-family: var(--r-heading-font); font-weight: 600; text-transform: none; letter-spacing: -0.025em; }
 .reveal h1 { font-size: 78px; line-height: 1.08; margin: 0 0 28px; max-width: 1000px; }
 .reveal h2 { font-size: 48px; line-height: 1.14; margin: 0 0 32px; max-width: 1100px; }
@@ -38,11 +38,17 @@ body { margin: 0; font-family: var(--r-main-font); color: var(--r-main-color); }
 .reveal .caption, .reveal .source { font-size: 24px; line-height: 1.4; }
 .reveal .source { margin-top: 24px; color: var(--course-muted); }
 .reveal .eyebrow { font-size: 24px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--course-accent); margin-bottom: 38px; }
-.reveal .title-slide { display: flex !important; flex-direction: column; justify-content: center; }
-.reveal .title-slide .subtitle { max-width: 980px; font-size: 34px; line-height: 1.4; color: var(--course-muted); }
+.reveal .title-slide {display: flex !important; flex-direction: column; justify-content: center; }
+.reveal .title-slide h1 { font-size: 68px; max-width: 1152px; }
+.reveal .title-slide .subtitle { max-width: 1000px; font-size: 34px; line-height: 1.4; color: var(--course-muted); }
 .reveal .title-slide .byline { margin-top: 52px; font-size: 26px; }
 .reveal .section-slide { display: flex !important; flex-direction: column; justify-content: center; }
 .reveal .section-slide h2 { font-size: 64px; max-width: 1000px; }
+.reveal .outline-topics { margin: 48px 0 0 1.1em; font-size: 48px; line-height: 1.25; }
+.reveal .outline-topics li { color: #c4c4c4; margin-bottom: 32px; padding-left: 8px; font-weight: 400; }
+.reveal .outline-topics li::marker { color: currentColor; }
+.reveal .outline-topics li[aria-current="step"] { color: #111; font-weight: 700; }
+.reveal .outline-slide .caption { margin-top: 36px; }
 .reveal .columns { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 64px; align-items: start; }
 .reveal .columns > * { min-width: 0; }
 .reveal .columns p:last-child { margin-bottom: 0; }
@@ -96,6 +102,12 @@ body { margin: 0; font-family: var(--r-main-font); color: var(--r-main-color); }
 html.reveal-print .reveal .slides section { height: 720px !important; padding: 54px 64px 58px !important; }
 html.reveal-print .reveal .slides section.title-slide,
 html.reveal-print .reveal .slides section.section-slide { display: flex !important; }
+/* Reveal copies the body background into an inline style on each PDF page. */
+html.reveal-print .reveal .slides .pdf-page { background: #fff !important; }
+@media screen {
+  html.reveal-print, html.reveal-print body { background: #e9edf1; }
+  html.reveal-print .reveal .slides .pdf-page:not(:last-of-type) { margin-bottom: 40px; }
+}
 @media print {
   .course-toolbar, .course-help, .course-error, .reveal .controls, .reveal .progress { display: none !important; }
   .reveal .slides section { print-color-adjust: exact; -webkit-print-color-adjust: exact; }

--- a/slides/tools/check.mjs
+++ b/slides/tools/check.mjs
@@ -133,39 +133,58 @@ try {
   assert.equal(await page.locator('#course-help').isVisible(), true);
   await page.getByRole('button', { name: 'Close', exact: true }).click();
   assert.equal(await page.locator('#course-help').isVisible(), false);
-  if (folder === 'example') {
+  if (folder === 'example' || folder === 'lecture-01') {
     await page.evaluate(() => Reveal.slide(Reveal.getIndices(document.getElementById('interactive-results')).h));
     const point = await page.locator('#interactive-results .point').nth(1).boundingBox();
     await page.mouse.move(point.x + point.width / 2, point.y + point.height / 2);
     await page.waitForFunction(() => document.querySelector('#interactive-results .hoverlayer').textContent.includes('Total tokens: 18'));
     assert.match(await page.locator('#interactive-results .hoverlayer').textContent(), /Total tokens: 18/);
-    await page.evaluate(() => Reveal.slide(4));
+    await page.evaluate(() => Reveal.slide(Reveal.getIndices(document.getElementById('browser-demo')).h));
     await page.getByLabel('Try English, Chinese, or emoji').fill('🙂');
     assert.equal(await page.locator('#point-count').textContent(), '1');
     assert.equal(await page.locator('#byte-count').textContent(), '4');
     await page.getByRole('button', { name: 'Reset example' }).click();
     assert.equal(await page.locator('#point-count').textContent(), '3');
     assert.equal(await page.locator('#byte-count').textContent(), '10');
-    await page.evaluate(() => Reveal.slide(7, 0, -1));
+    await page.evaluate(() => Reveal.slide(Reveal.getIndices(document.getElementById('exercise-01')).h, 0, -1));
     assert.equal(await page.locator('#exercise-01 .answer').evaluate(el => el.classList.contains('visible')), false);
     await page.keyboard.press('Space');
     assert.equal(await page.locator('#exercise-01 .answer').evaluate(el => el.classList.contains('visible')), true);
     await page.keyboard.press('Escape');
     assert.equal(await page.evaluate(() => Reveal.isOverview()), true);
     await page.keyboard.press('Escape');
-    await page.waitForURL(url => url.hash === '#/exercise-01');
+    await page.waitForURL(url => /^#\/exercise-01(?:\/\d+)?$/.test(url.hash));
     await page.reload({ waitUntil: 'networkidle' });
     await page.evaluate(() => window.courseReady);
     assert.equal(await page.evaluate(() => Reveal.getCurrentSlide().id), 'exercise-01');
     assert.ok(await page.locator('.katex').count() > 0, 'Sample equations did not render.');
+  }
+  if (folder === 'lecture-01') {
+    const outlines = await page.locator('.outline-topics').evaluateAll(lists => lists.map(list => ({
+      topics: [...list.children].map(item => item.textContent),
+      active: [...list.children].flatMap((item, index) => item.matches('[aria-current="step"]') ? [index] : []),
+    })));
+    assert.equal(outlines.length, 5);
+    for (const outline of outlines) assert.deepEqual(outline.topics, outlines[0].topics);
+    assert.deepEqual(outlines.map(outline => outline.active), [[0], [1], [2], [3], [3]]);
   }
   if (exportPDF) {
     await page.goto(url + '?print-pdf', { waitUntil: 'networkidle' });
     await page.evaluate(() => window.courseReady);
     await page.waitForFunction(expected => document.querySelectorAll('.pdf-page').length === expected, count);
     await page.evaluate(() => document.fonts.ready);
+    await page.setViewportSize({ width: 1600, height: 1000 });
+    await page.screenshot({ path: path.join(output, 'print-preview.png'), animations: 'disabled' });
     const printPadding = await page.locator('.pdf-page section').evaluateAll(sections => sections.map(section => parseFloat(getComputedStyle(section).paddingLeft)));
     assert.ok(printPadding.every(padding => padding >= 64), 'PDF export must preserve the slide content margins.');
+    const printOverflow = await page.locator('.pdf-page section').evaluateAll(sections => sections.flatMap(section => {
+      const box = section.getBoundingClientRect();
+      return [...section.querySelectorAll('h1,h2,p,li,pre,table,.plot')]
+        .filter(el => !el.closest('aside.notes'))
+        .filter(el => el.getBoundingClientRect().bottom > box.bottom - 35)
+        .map(el => `${section.id}: ${el.textContent.trim().slice(0, 60)}`);
+    }));
+    assert.deepEqual(printOverflow, [], 'Content extends into the PDF slide footer.');
     await page.pdf({ path: path.join(output, `${folder}.pdf`), printBackground: true, preferCSSPageSize: true });
   }
   assert.deepEqual(errors, [], 'Browser errors or missing runtime assets.');

--- a/tests/test_lecture_01.py
+++ b/tests/test_lecture_01.py
@@ -1,0 +1,181 @@
+"""Check the executable teaching material directly from the distributed notebook."""
+
+import base64
+import io
+import json
+import re
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+
+import nbformat
+import pytest
+
+
+LECTURE = Path(__file__).resolve().parents[1] / "slides/lecture-01"
+NOTEBOOK = json.loads((LECTURE / "lecture-01-exercise.ipynb").read_text())
+
+
+def execute_cell(cell, namespace):
+    exec(compile("".join(cell["source"]), cell["id"], "exec"), namespace)
+
+
+@pytest.fixture
+def lesson(monkeypatch):
+    monkeypatch.setenv("COURSE_RUN_OLLAMA", "0")
+    namespace = {}
+    for cell in NOTEBOOK["cells"]:
+        tags = cell["metadata"].get("tags", [])
+        if cell["cell_type"] == "code" and set(tags) & {"definitions", "bpe-definition"}:
+            execute_cell(cell, namespace)
+    return namespace
+
+
+def test_notebook_runs_offline_without_network(monkeypatch, capsys):
+    def no_network(*args, **kwargs):
+        pytest.fail("The offline notebook attempted a network request")
+
+    monkeypatch.setenv("COURSE_RUN_OLLAMA", "0")
+    monkeypatch.setattr("urllib.request.OpenerDirector.open", no_network)
+    nbformat.validate(nbformat.from_dict(NOTEBOOK))
+    namespace = {}
+    for cell in NOTEBOOK["cells"]:
+        if cell["cell_type"] == "code":
+            execute_cell(cell, namespace)
+    assert namespace["OLLAMA_READY"] is False
+    figure = json.loads((LECTURE / "assets/sequence-length.json").read_text())
+    assert namespace["totals"] == figure["data"][0]["y"]
+    assert len(namespace["comparison_rows"]) == 12
+    assert all(row["roundtrip"] for row in namespace["comparison_rows"])
+    heldout_figure = json.loads((LECTURE / "assets/heldout-chinese.json").read_text())
+    for trace, training in zip(heldout_figure["data"], ["EN + ZH", "EN only"]):
+        rows = [row for row in namespace["comparison_rows"]
+                if row["training"] == training and row["language"] == "Chinese"]
+        assert trace["x"] == [row["learned"] for row in rows]
+        assert trace["y"] == [row["tokens"] for row in rows]
+    assert "NFC can make these strings equal" in capsys.readouterr().out
+
+
+def test_displayed_python_examples_run(capsys):
+    source = (LECTURE / "slides.md").read_text()
+    blocks = re.findall(r"```python\n(.*?)\n```", source, re.DOTALL)
+    assert blocks
+    for index, block in enumerate(blocks):
+        exec(compile(block, f"slides.md Python block {index + 1}", "exec"), {})
+    assert "你好 2 6" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("text", ["", "lowest", "你好🙂", "e\u0301", "\n\t  ", "a\x00b", "<|endoftext|>"])
+def test_unseen_text_roundtrips_without_changing_vocabulary(lesson, text):
+    vocab, merges, _ = lesson["train_bpe"]([("low", 5), ("lower", 2)], 2)
+    tokenizer = lesson["ByteBPETokenizer"](vocab, merges)
+    before = dict(tokenizer.vocab)
+    assert tokenizer.decode(tokenizer.encode(text)) == text
+    assert tokenizer.vocab == before
+    assert len(tokenizer.vocab) == 258
+
+
+def test_pair_counts_include_overlap_but_replacements_do_not(lesson):
+    counts = lesson["count_pairs"]([([97, 97, 97, 98], 2), ([97, 98], 1)])
+    assert counts == {(97, 97): 4, (97, 98): 3}
+    vocab, merges, totals = lesson["train_bpe"]([("aaab", 2), ("ab", 1)], 1)
+    tokenizer = lesson["ByteBPETokenizer"](vocab, merges)
+    assert tokenizer.pieces("aaab") == [b"aa", b"a", b"b"]
+    assert totals == [10, 8]
+
+
+def test_tie_breaking_is_independent_of_corpus_order(lesson):
+    first = lesson["train_bpe"]([("low", 5), ("lower", 2)], 2)
+    second = lesson["train_bpe"]([("lower", 2), ("low", 5)], 2)
+    assert first == second
+    assert [first[0][index] for _, index in first[1]] == [b"lo", b"low"]
+
+
+def test_encoding_obeys_learned_rank_not_leftmost_position(lesson):
+    vocab, merges, _ = lesson["train_bpe"]([("bc", 3), ("ab", 2)], 2)
+    tokenizer = lesson["ByteBPETokenizer"](vocab, merges)
+    assert tokenizer.pieces("abc") == [b"a", b"bc"]
+
+
+@pytest.mark.parametrize("corpus", [[], [("", 1)], [("a", 2), ("b", 3)]])
+def test_no_pairs_stops_without_merging_document_boundaries(lesson, corpus):
+    vocab, merges, totals = lesson["train_bpe"](corpus, 100)
+    assert len(vocab) == 256
+    assert merges == []
+    assert len(totals) == 1
+
+
+@pytest.mark.parametrize("corpus,budget", [([("x", 0)], 2), ([("x", -1)], 2),
+                                          ([("x", 1.5)], 2), ([(b"x", 1)], 2),
+                                          ([("x", 1)], -1), ([("x", 1)], 1.5)])
+def test_invalid_training_inputs_are_rejected(lesson, corpus, budget):
+    with pytest.raises(ValueError):
+        lesson["train_bpe"](corpus, budget)
+
+
+def test_decoding_incomplete_utf8_fails_explicitly(lesson):
+    vocab, merges, _ = lesson["train_bpe"]([], 0)
+    tokenizer = lesson["ByteBPETokenizer"](vocab, merges)
+    with pytest.raises(UnicodeDecodeError):
+        tokenizer.decode([228])
+    with pytest.raises(KeyError):
+        tokenizer.decode([256])
+
+
+def test_ollama_client_uses_local_json_request(lesson, monkeypatch):
+    requests = []
+
+    def open_request(request, timeout):
+        requests.append((request, timeout))
+        return io.BytesIO(json.dumps({"response": "Shanghai"}).encode())
+
+    monkeypatch.setattr(lesson["local_http"], "open", open_request)
+    payload = {"model": "qwen3:0.6b", "prompt": "你好", "stream": False}
+    result = lesson["ollama_request"]("/api/generate", payload)
+    request, timeout = requests[0]
+    assert request.full_url == "http://127.0.0.1:11434/api/generate"
+    assert request.get_method() == "POST"
+    assert json.loads(request.data) == payload
+    assert timeout == 120
+    assert result["response"] == "Shanghai"
+
+
+@pytest.mark.parametrize("failure,expected", [
+    (URLError("connection refused"), "Cannot reach Ollama"),
+    (TimeoutError(), "timed out"),
+    (HTTPError("http://127.0.0.1:11434", 404, "missing", {},
+               io.BytesIO(b'{"error":"model not found"}')), "model not found"),
+])
+def test_ollama_failures_report_actionable_errors(lesson, monkeypatch, failure, expected):
+    def open_request(*args, **kwargs):
+        raise failure
+
+    monkeypatch.setattr(lesson["local_http"], "open", open_request)
+    with pytest.raises(RuntimeError, match=expected):
+        lesson["ollama_request"]("/api/tags")
+
+
+def test_generation_keeps_thinking_options_at_the_api_top_level(lesson, monkeypatch):
+    payloads = []
+
+    def request(endpoint, payload):
+        payloads.append(payload)
+        return {"response": "Shanghai", "done_reason": "stop"}
+
+    monkeypatch.setitem(lesson, "ollama_request", request)
+    lesson["OLLAMA_READY"] = True
+    lesson["generate"]("A prompt", think=True, logprobs=True, max_tokens=20)
+    assert payloads[0]["think"] is True
+    assert payloads[0]["logprobs"] is True
+    assert payloads[0]["stream"] is False
+    assert payloads[0]["options"]["num_predict"] == 20
+    assert "think" not in payloads[0]["options"]
+
+
+def test_vision_request_sends_image_bytes_in_the_user_message(lesson):
+    image_bytes = b"test image payload"
+    payload = lesson["vision_payload"](image_bytes, "installed-vision-model")
+    message = payload["messages"][0]
+    assert message["role"] == "user"
+    assert base64.b64decode(message["images"][0]) == image_bytes
+    assert payload["model"] == "installed-vision-model"
+    assert payload["stream"] is False


### PR DESCRIPTION
Lecture 01 currently contains a short format sample. This replaces it with a 49-slide teaching draft for three 45-minute periods, combining the previous Fudan introduction with Stanford CS336's tokenizer progression. The draft establishes a working lecture and notebook that can be revised as teaching plans develop.

The deck covers course introduction, language-model development, Unicode and UTF-8, and byte BPE. Repeated outlines highlight the current topic in bold black. Five matching notebook exercises check sentiment, Unicode counts, overlapping pairs, encoding unseen text, and held-out English/Chinese comparisons. Ollama demonstrations run from the notebook; the core tokenization exercises work offline. Minimum edit distance is excluded.

Includes the teaching plan and CS336 preparation notes, checked Plotly toy results, the updated title page, print-preview styling, and notebook-update instructions that preserve students' saved work.

Validation:

- `uv run python -m pytest tests/`: 59 passed.
- `npm --prefix slides run check -- lecture-01 --pdf`: all 49 slides passed at three viewport sizes; every slide image reviewed and the 49-page PDF checked.
- `npm --prefix slides run check -- example --pdf`: shared-theme regression check passed.
- `npm --prefix slides run check:notebook -- http://127.0.0.1:8000 lecture-01 --course-page`: new-tab launch, server reuse, course kernel, and static-server guidance passed.
- Core notebook executed in a Jupyter kernel. Live local Ollama text calls, log probabilities, thinking output, and both optional named tiktoken encodings checked. Vision request construction is tested; a live vision model was not available.

Related to #6.
