### PR TITLE
Add the tasks folder, task template, example task, and tasks tool

### DIFF
--- a/docs/participation-workflow.md
+++ b/docs/participation-workflow.md
@@ -89,11 +89,11 @@ flowchart TB
     end
     subgraph S[Students]
         direction LR
-        S1[Read the issue;\ncomment: I'll take this] --> S2[Fork, branch, work in workspace/;\nadd tasks/l02-ngram/slug/username.md] --> S3[Open PR;\ntitle l02-ngram/slug: username;\nbody Related to #issue] --> S4[Red check?\npush a fix to the same branch]
+        S1[Read the issue;\ncomment: I'll take this] --> S2[Fork, branch, work in workspace/;\nadd tasks/l02-ngram/slug/submissions/username.py] --> S3[Open PR;\ntitle l02-ngram/slug: username;\nbody Related to #issue] --> S4[Red check?\npush a fix to the same branch]
     end
     subgraph C[CI on every PR]
         direction LR
-        C1[Check path, filename,\nrequired headings and numbers,\nonly one file changed] --> C2{green?}
+        C1[Run the task's tests/test_task.py\non the submission;\nonly one file changed] --> C2{green?}
     end
     I1 -. assigns after comment .-> S1
     S3 --> C1
@@ -148,8 +148,8 @@ still L05), and zero-padding keeps them sorted.
 | --- | --- | --- |
 | Issue title | `<lecture label>: <short title>` | `l02-ngram: bigram perplexity on your own text` |
 | Issue labels | one lecture label + one type label | `l02-ngram`, `task` |
-| Issue body | Task, exact file path, required headings or numbers, how it is checked, deadline | see the issue template |
-| Student file | `tasks/<lecture label>/<slug>/<username>.md` (or `.ipynb`), username in lowercase | `tasks/l02-ngram/bigram-perplexity/octocat.md` |
+| Issue body | Link to the task folder; the folder's `instruction.md` holds goal, interface, examples, checker, deadline | `tasks/l02-ngram/bigram-perplexity/` |
+| Student file | `tasks/<lecture label>/<slug>/submissions/<username>.py`, username in lowercase (see [tasks/README.md](../tasks/README.md)) | `tasks/l02-ngram/bigram-perplexity/submissions/octocat.py` |
 | PR title | `<lecture label>/<slug>: <username>` | `l02-ngram/bigram-perplexity: octocat` |
 | PR body | `Related to #<issue>` | `Related to #45` |
 | Branch in the fork | `<lecture label>-<slug>` | `l02-ngram-bigram-perplexity` |

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -1,0 +1,104 @@
+"""Create, check, and tally course tasks under tasks/.
+
+    uv run python scripts/tasks.py new l02-ngram split-sentences "Split text into sentences"
+    uv run python scripts/tasks.py check tasks/l02-ngram/split-sentences [username]
+    uv run python scripts/tasks.py list
+    uv run python scripts/tasks.py progress
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tomllib
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TASKS = ROOT / "tasks"
+SKIP = {"TEMPLATE"}
+
+
+def create_task(lecture: str, slug: str, title: str, tasks_root: Path = TASKS) -> Path:
+    """Copy TEMPLATE/ to tasks/<lecture>/<slug>/ and fill in the placeholders."""
+    for name, value in (("lecture", lecture), ("slug", slug)):
+        if not re.fullmatch(r"[a-z0-9]+(-[a-z0-9]+)*", value):
+            raise ValueError(f"{name} must be lowercase words joined by hyphens, got {value!r}")
+    destination = tasks_root / lecture / slug
+    if destination.exists():
+        raise FileExistsError(f"{destination} already exists")
+    shutil.copytree(tasks_root / "TEMPLATE", destination)
+    for path in destination.rglob("*"):
+        if path.is_file() and path.suffix in {".toml", ".md", ".py"}:
+            text = path.read_text(encoding="utf-8")
+            text = text.replace("{{LECTURE}}", lecture).replace("{{SLUG}}", slug).replace("{{TITLE}}", title)
+            path.write_text(text, encoding="utf-8")
+    return destination
+
+
+def task_folders(tasks_root: Path = TASKS) -> list[Path]:
+    return sorted(p.parent for p in tasks_root.glob("*/*/task.toml") if p.parent.parent.name not in SKIP)
+
+
+def manifest(folder: Path) -> dict:
+    return tomllib.loads((folder / "task.toml").read_text(encoding="utf-8"))
+
+
+def submissions(folder: Path) -> list[str]:
+    return sorted(p.stem for p in (folder / "submissions").glob("*.py"))
+
+
+def check(folder: Path, username: str | None = None) -> int:
+    """Run the task's checker with pytest; returns the exit code."""
+    command = [sys.executable, "-m", "pytest", "-q", str(folder / "tests")]
+    if username:
+        command += ["-k", username]
+    return subprocess.call(command, cwd=ROOT)
+
+
+def list_tasks(tasks_root: Path = TASKS) -> str:
+    rows = ["| Task | Title | Difficulty | Deadline | Submissions |", "| :--- | :--- | :--- | :--- | ---: |"]
+    for folder in task_folders(tasks_root):
+        info = manifest(folder)["task"]
+        rows.append(f"| {info['id']} | {info['title']} | {info['difficulty']} | {str(info['deadline'])[:10]} | {len(submissions(folder))} |")
+    return "\n".join(rows)
+
+
+def progress(tasks_root: Path = TASKS) -> str:
+    counts: Counter = Counter()
+    for folder in task_folders(tasks_root):
+        counts.update(submissions(folder))
+    rows = ["| Student | Tasks submitted |", "| :--- | ---: |"]
+    rows += [f"| {user} | {count} |" for user, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))]
+    return "\n".join(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+    new = sub.add_parser("new", help="Create a task folder from TEMPLATE/")
+    new.add_argument("lecture", help="lecture label, e.g. l02-ngram")
+    new.add_argument("slug", help="short task name, e.g. split-sentences")
+    new.add_argument("title")
+    run = sub.add_parser("check", help="Run a task's checker on every submission, or on one username")
+    run.add_argument("task", type=Path)
+    run.add_argument("username", nargs="?")
+    sub.add_parser("list", help="Table of tasks with deadlines and submission counts")
+    sub.add_parser("progress", help="Table of submissions per student")
+    args = parser.parse_args()
+
+    if args.command == "new":
+        print(create_task(args.lecture, args.slug, args.title))
+    elif args.command == "check":
+        sys.exit(check(args.task.resolve(), args.username))
+    elif args.command == "list":
+        print(list_tasks())
+    elif args.command == "progress":
+        print(progress())
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -1,0 +1,65 @@
+# Tasks
+
+Small, self-checking exercises that anyone in the class can do. Each task is
+one folder; each student submits **one file** into that folder's
+`submissions/` directory through a pull request. A checker runs the same
+tests on every submission, so you know you are done before you open the PR.
+
+```text
+tasks/
+  README.md                      this page
+  TEMPLATE/                      copy this to create a task
+  example/word-count/            a complete, tiny example
+  l02-ngram/<slug>/              real tasks, grouped by lecture label
+    task.toml                    id, title, deadline, what to submit
+    instruction.md               the task: goal, interface, examples, how it is checked
+    tests/test_task.py           the checker, run on every file in submissions/
+    submissions/<username>.py    one file per student
+```
+
+Task issues on GitHub carry the same lecture label as the folder
+(`l02-ngram`, `l03-embeddings`, …) plus the type label `task`. The full
+rules, timeline, and labels are in
+[docs/participation-workflow.md](../docs/participation-workflow.md).
+
+## Students: do a task
+
+1. Pick an open issue labelled `task` and comment "I'll take this".
+2. Read the task's `instruction.md`. It says exactly which file to create.
+3. Write your file as `submissions/<your-github-username>.py` (lowercase),
+   then check it:
+
+   ```sh
+   uv run python scripts/tasks.py check tasks/l02-ngram/<slug> <username>
+   ```
+
+4. When the check passes, open a PR from your fork with the title
+   `l02-ngram/<slug>: <username>` and `Related to #<issue>` in the body.
+   Only your one file should be in the PR.
+5. Deadline: Tuesday 23:59 of the same week. Late PRs are merged if they pass
+   but are not counted for that week.
+
+Try it first on the example: copy `tasks/example/word-count/submissions/octocat.py`
+to `<username>.py` in the same folder and run the check.
+
+## Teaching team: create a task
+
+```sh
+uv run python scripts/tasks.py new l02-ngram split-sentences "Split text into sentences"
+```
+
+This copies `TEMPLATE/` to `tasks/l02-ngram/split-sentences/`. Then:
+
+1. Fill in `instruction.md`. Keep the six headings; a task should take a
+   student 30–60 minutes.
+2. Edit `tests/test_task.py`: set `FUNCTION` and `CASES`. Add a hidden-input
+   test only if the cases alone would be too easy to copy.
+3. Set the deadline and time estimate in `task.toml`.
+4. Run `uv run python scripts/tasks.py check tasks/l02-ngram/split-sentences`
+   with a reference submission of your own, then delete it (solutions stay in
+   the private instructors' repository).
+5. Open the GitHub issue with the same title, labels `l02-ngram` + `task`,
+   and a link to the folder.
+
+`uv run python scripts/tasks.py list` shows every task with its deadline and
+submission count; `progress` prints merged submissions per student.

--- a/tasks/TEMPLATE/instruction.md
+++ b/tasks/TEMPLATE/instruction.md
@@ -1,0 +1,45 @@
+# {{TITLE}}
+
+**Lecture:** {{LECTURE}} · **Difficulty:** easy · **Time:** about 45 minutes ·
+**Deadline:** Tuesday 23:59
+
+## Goal
+
+REPLACE: One sentence saying what the student will be able to do afterwards.
+
+## What you submit
+
+One file: `submissions/<your-github-username>.py` containing a function
+
+```python
+def solve(text: str) -> list[str]:
+    ...
+```
+
+REPLACE: Describe the input and the output precisely (types, order, edge cases).
+
+## Examples
+
+| Input | Output |
+| :--- | :--- |
+| REPLACE `"..."` | REPLACE `[...]` |
+| REPLACE `""` | REPLACE `[]` |
+
+## How it is checked
+
+`tests/test_task.py` calls your `solve` on the examples above and on a few
+similar cases. Run it yourself before opening the PR:
+
+```sh
+uv run python scripts/tasks.py check tasks/{{LECTURE}}/{{SLUG}} <username>
+```
+
+## Rules
+
+- Standard library only unless the instruction says otherwise.
+- Use your own words and code; discussing the approach with classmates is fine.
+- PR title `{{LECTURE}}/{{SLUG}}: <username>`, body `Related to #<issue>`.
+
+## Why this matters
+
+REPLACE: One or two sentences linking the task to the lecture.

--- a/tasks/TEMPLATE/submissions/README.md
+++ b/tasks/TEMPLATE/submissions/README.md
@@ -1,0 +1,2 @@
+One file per student, named `<github-username>.py` in lowercase. Nothing
+else goes in this folder. See `../instruction.md` for what the file contains.

--- a/tasks/TEMPLATE/task.toml
+++ b/tasks/TEMPLATE/task.toml
@@ -1,0 +1,15 @@
+# One task = one folder. Students add one file each under submissions/.
+
+[task]
+id = "{{LECTURE}}/{{SLUG}}"          # folder path under tasks/, also the PR title prefix
+title = "{{TITLE}}"
+lecture = "{{LECTURE}}"              # GitHub lecture label, e.g. l02-ngram
+type = "task"                        # task | help-wanted | figure
+difficulty = "easy"                  # easy | medium | hard
+time_minutes = 45                    # typical time for a student
+deadline = "2026-09-22T23:59:00+08:00"
+issue = 0                            # GitHub issue number once opened
+
+[submission]
+file = "submissions/<username>.py"   # exactly one file per student
+function = "solve"                   # the function tests/test_task.py calls

--- a/tasks/TEMPLATE/tests/test_task.py
+++ b/tasks/TEMPLATE/tests/test_task.py
@@ -1,0 +1,37 @@
+"""Checker for every file in submissions/. Task authors edit FUNCTION and CASES only.
+
+Run one student:  uv run python scripts/tasks.py check tasks/<lecture>/<slug> <username>
+Run everyone:     uv run python scripts/tasks.py check tasks/<lecture>/<slug>
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+FUNCTION = "solve"
+CASES = [
+    # (input, expected output)
+    ("REPLACE", ["REPLACE"]),
+    ("", []),
+]
+
+SUBMISSIONS = sorted(p for p in (Path(__file__).resolve().parents[1] / "submissions").glob("*.py"))
+
+
+def load(path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, FUNCTION)
+
+
+@pytest.mark.parametrize("submission", SUBMISSIONS, ids=[p.stem for p in SUBMISSIONS])
+def test_filename_is_a_lowercase_username(submission):
+    assert submission.stem == submission.stem.lower(), "name the file <username>.py in lowercase"
+
+
+@pytest.mark.parametrize("submission", SUBMISSIONS, ids=[p.stem for p in SUBMISSIONS])
+@pytest.mark.parametrize("text,expected", CASES)
+def test_cases(submission, text, expected):
+    assert load(submission)(text) == expected

--- a/tasks/example/word-count/instruction.md
+++ b/tasks/example/word-count/instruction.md
@@ -1,0 +1,51 @@
+# Count words with a regular expression
+
+**Lecture:** example · **Difficulty:** easy · **Time:** about 20 minutes ·
+**Deadline:** none (this is the practice task)
+
+## Goal
+
+Use `re.findall` to split English text into words, the first step of every
+tokenizer in Lecture 01.
+
+## What you submit
+
+One file: `submissions/<your-github-username>.py` containing a function
+
+```python
+def solve(text: str) -> list[str]:
+    ...
+```
+
+Input: any string. Output: the words in order, lowercased, where a word is a
+run of ASCII letters, digits, or apostrophes. Punctuation and whitespace are
+not words. An empty string gives an empty list.
+
+## Examples
+
+| Input | Output |
+| :--- | :--- |
+| `"It's hard to recognize speech."` | `["it's", "hard", "to", "recognize", "speech"]` |
+| `"GPT-4 has 2 tokens"` | `["gpt", "4", "has", "2", "tokens"]` |
+| `""` | `[]` |
+
+## How it is checked
+
+`tests/test_task.py` calls your `solve` on the examples above and on a few
+similar cases. Run it yourself before opening the PR:
+
+```sh
+uv run python scripts/tasks.py check tasks/example/word-count <username>
+```
+
+## Rules
+
+- Standard library only (`re` is enough).
+- Use your own words and code; discussing the approach with classmates is fine.
+- PR title `example/word-count: <username>`, body `Related to #<issue>`.
+
+## Why this matters
+
+Lecture 01 tokenizes text before anything else happens. A regular expression
+is the simplest tokenizer, and its choices (what counts as a word) already
+change the vocabulary the model sees.

--- a/tasks/example/word-count/submissions/README.md
+++ b/tasks/example/word-count/submissions/README.md
@@ -1,0 +1,3 @@
+One file per student, named `<github-username>.py` in lowercase. Nothing
+else goes in this folder. See `../instruction.md` for what the file contains.
+`octocat.py` is the sample submission for this practice task.

--- a/tasks/example/word-count/submissions/octocat.py
+++ b/tasks/example/word-count/submissions/octocat.py
@@ -1,0 +1,9 @@
+"""Sample submission for tasks/example/word-count (octocat is GitHub's mascot)."""
+
+import re
+
+WORD = re.compile(r"[A-Za-z0-9']+")
+
+
+def solve(text: str) -> list[str]:
+    return [word.lower() for word in WORD.findall(text)]

--- a/tasks/example/word-count/task.toml
+++ b/tasks/example/word-count/task.toml
@@ -1,0 +1,15 @@
+# One task = one folder. Students add one file each under submissions/.
+
+[task]
+id = "example/word-count"
+title = "Count words with a regular expression"
+lecture = "example"
+type = "task"
+difficulty = "easy"
+time_minutes = 20
+deadline = "2026-12-31T23:59:00+08:00"
+issue = 0
+
+[submission]
+file = "submissions/<username>.py"
+function = "solve"

--- a/tasks/example/word-count/tests/test_task.py
+++ b/tasks/example/word-count/tests/test_task.py
@@ -1,0 +1,39 @@
+"""Checker for every file in submissions/. Task authors edit FUNCTION and CASES only.
+
+Run one student:  uv run python scripts/tasks.py check tasks/example/word-count <username>
+Run everyone:     uv run python scripts/tasks.py check tasks/example/word-count
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+FUNCTION = "solve"
+CASES = [
+    ("It's hard to recognize speech.", ["it's", "hard", "to", "recognize", "speech"]),
+    ("GPT-4 has 2 tokens", ["gpt", "4", "has", "2", "tokens"]),
+    ("", []),
+    ("  Wow...   Loved this place!  ", ["wow", "loved", "this", "place"]),
+    ("BOS I am Sam EOS", ["bos", "i", "am", "sam", "eos"]),
+]
+
+SUBMISSIONS = sorted(p for p in (Path(__file__).resolve().parents[1] / "submissions").glob("*.py"))
+
+
+def load(path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, FUNCTION)
+
+
+@pytest.mark.parametrize("submission", SUBMISSIONS, ids=[p.stem for p in SUBMISSIONS])
+def test_filename_is_a_lowercase_username(submission):
+    assert submission.stem == submission.stem.lower(), "name the file <username>.py in lowercase"
+
+
+@pytest.mark.parametrize("submission", SUBMISSIONS, ids=[p.stem for p in SUBMISSIONS])
+@pytest.mark.parametrize("text,expected", CASES)
+def test_cases(submission, text, expected):
+    assert load(submission)(text) == expected

--- a/tests/test_tasks_tool.py
+++ b/tests/test_tasks_tool.py
@@ -1,0 +1,71 @@
+"""Check the task template, the example task, and scripts/tasks.py."""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import tasks
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUIRED = ["task.toml", "instruction.md", "tests/test_task.py", "submissions/README.md"]
+
+
+@pytest.fixture
+def tasks_root(tmp_path):
+    shutil.copytree(ROOT / "tasks/TEMPLATE", tmp_path / "TEMPLATE")
+    return tmp_path
+
+
+def test_every_task_folder_has_the_required_files():
+    folders = tasks.task_folders()
+    assert folders, "no tasks found"
+    for folder in folders + [ROOT / "tasks/TEMPLATE"]:
+        for name in REQUIRED:
+            assert (folder / name).exists(), f"{folder.name} is missing {name}"
+        info = tasks.manifest(folder)
+        assert set(info) == {"task", "submission"}
+        assert info["task"]["difficulty"] in {"easy", "medium", "hard"}
+
+
+def test_example_submission_passes_its_checker():
+    result = subprocess.run([sys.executable, "-m", "pytest", "-q", "tasks/example/word-count/tests", "-k", "octocat"],
+                            cwd=ROOT, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert " passed" in result.stdout and "failed" not in result.stdout
+
+
+def test_new_task_fills_placeholders_and_checks_a_submission(tasks_root):
+    folder = tasks.create_task("l02-ngram", "split-sentences", "Split text into sentences", tasks_root)
+    assert folder == tasks_root / "l02-ngram/split-sentences"
+    text = "".join(p.read_text() for p in folder.rglob("*") if p.is_file())
+    assert "{{" not in text
+    info = tasks.manifest(folder)["task"]
+    assert info == {**info, "id": "l02-ngram/split-sentences", "lecture": "l02-ngram", "title": "Split text into sentences"}
+    assert "l02-ngram/split-sentences: <username>" in (folder / "instruction.md").read_text()
+    with pytest.raises(FileExistsError):
+        tasks.create_task("l02-ngram", "split-sentences", "again", tasks_root)
+    with pytest.raises(ValueError):
+        tasks.create_task("L02 ngram", "x", "bad label", tasks_root)
+
+
+def test_template_checker_rejects_uppercase_filenames_and_wrong_answers(tasks_root):
+    folder = tasks.create_task("l02-ngram", "demo", "Demo", tasks_root)
+    (folder / "submissions/Octocat.py").write_text("def solve(text):\n    return ['REPLACE'] if text else []\n")
+    (folder / "submissions/wrong.py").write_text("def solve(text):\n    return []\n")
+    result = subprocess.run([sys.executable, "-m", "pytest", "-q", str(folder / "tests")], cwd=ROOT,
+                            capture_output=True, text=True)
+    assert result.returncode != 0
+    assert "test_filename_is_a_lowercase_username[Octocat]" in result.stdout
+    assert "test_cases[REPLACE-expected0-wrong]" in result.stdout
+    assert "2 failed, 4 passed" in result.stdout
+
+
+def test_list_and_progress_tables(tasks_root):
+    folder = tasks.create_task("l02-ngram", "demo", "Demo", tasks_root)
+    (folder / "submissions/alice.py").write_text("def solve(text):\n    return []\n")
+    (folder / "submissions/bob.py").write_text("def solve(text):\n    return []\n")
+    assert "| l02-ngram/demo | Demo | easy | 2026-09-22 | 2 |" in tasks.list_tasks(tasks_root)
+    assert tasks.progress(tasks_root).splitlines()[2:] == ["| alice | 1 |", "| bob | 1 |"]


### PR DESCRIPTION
A lightweight task format modelled on Terminal-Bench Science tasks (manifest + instruction + tests), sized for a course exercise.

**Layout**

```text
tasks/
  README.md                 how to do a task (students) and how to create one (teaching team)
  TEMPLATE/                 copied by `scripts/tasks.py new`
    task.toml               id, lecture label, difficulty, time, deadline, what to submit
    instruction.md          goal, what you submit, examples, how it is checked, rules, why it matters
    tests/test_task.py      runs on every submissions/<username>.py; authors edit FUNCTION and CASES only
    submissions/            one file per student
  example/word-count/       complete tiny example with a sample submission (octocat.py)
```

**Tool**

```sh
uv run python scripts/tasks.py new l02-ngram split-sentences "Split text into sentences"
uv run python scripts/tasks.py check tasks/example/word-count octocat
uv run python scripts/tasks.py list
uv run python scripts/tasks.py progress
```

The checker rejects files whose name is not a lowercase username and reports each failing case. `docs/participation-workflow.md` now points at `submissions/<username>.py`.

Task content is the instructor's; this PR adds only the template, the example, and the plumbing.

Verified: `uv run python -m pytest tests/` (103 passed), including tests for the template, the example, and the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LvnWe7Tmic9MjdL3b2oQK
