### PR TITLE
Add issue forms for task proposals and material problems, plus a PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: How tasks and pull requests work
+    url: https://github.com/baojian/llm-26-fall/blob/main/docs/participation-workflow.md
+    about: Timeline, labels, file names, and deadlines for weekly tasks.

--- a/.github/ISSUE_TEMPLATE/course-material-problem.yml
+++ b/.github/ISSUE_TEMPLATE/course-material-problem.yml
@@ -1,0 +1,30 @@
+name: Report a problem in course material
+description: A typo, a broken link, a notebook cell that fails, or a slide that is unclear.
+title: "<lecture>: <what is wrong>"
+labels: ["bug"]
+body:
+  - type: input
+    id: where
+    attributes:
+      label: Where
+      description: File and slide or cell, or a URL.
+      placeholder: slides/lecture-02/slides.md, slide "Perplexity"; or http://127.0.0.1:8000/slides/lecture-02/#/24
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What is wrong
+      description: What you saw, and what you expected. Paste the error text if there is one.
+    validations:
+      required: true
+  - type: dropdown
+    id: fix
+    attributes:
+      label: Would you like to fix it yourself in a PR?
+      description: Fixes are welcome and count as a task.
+      options:
+        - "Yes, assign me"
+        - "No, just reporting"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/propose-task.yml
+++ b/.github/ISSUE_TEMPLATE/propose-task.yml
@@ -1,0 +1,78 @@
+name: Propose a task
+description: Suggest a small exercise for the class. If accepted, it becomes a task folder and you are credited.
+title: "proposal: <short title>"
+labels: ["proposal"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A good task takes a classmate 30–60 minutes, needs only the standard library, and can be checked by a few input/output cases. See `tasks/README.md` and `tasks/example/word-count/` for the shape.
+  - type: dropdown
+    id: lecture
+    attributes:
+      label: Lecture
+      description: Which lecture the task belongs to.
+      options:
+        - l01-tokenization
+        - l02-ngram
+        - l03-embeddings
+        - l04-attention
+        - l05-makeup
+        - l06-transformer
+        - l07-pretraining
+        - l08-data
+        - l09-scaling
+        - l10-evaluation
+        - l11-sft
+        - l12-alignment
+        - l13-rag
+        - l14-inference
+        - l15-diffusion
+        - l16-agents
+    validations:
+      required: true
+  - type: input
+    id: goal
+    attributes:
+      label: Goal
+      description: One sentence. What will a student be able to do after this task?
+      placeholder: Split raw text into sentences and add BOS/EOS tokens with a regular expression.
+    validations:
+      required: true
+  - type: textarea
+    id: interface
+    attributes:
+      label: What a student submits
+      description: The function signature or file format, with input and output types.
+      placeholder: |
+        def solve(text: str) -> list[str]
+        Input: any string. Output: sentences in order, each wrapped as "BOS ... EOS".
+    validations:
+      required: true
+  - type: textarea
+    id: examples
+    attributes:
+      label: Two examples
+      description: Input and expected output. These become the first test cases.
+      placeholder: |
+        "I am Sam. Sam I am." -> ["BOS I am Sam EOS", "BOS Sam I am EOS"]
+        "" -> []
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this matters
+      description: One or two sentences linking the task to the lecture, and what you found hard about it yourself.
+    validations:
+      required: false
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Difficulty
+      options:
+        - easy
+        - medium
+        - hard
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+Related to #<!-- issue number -->
+
+<!-- Keep the three checks below. Delete this comment. -->
+
+- [ ] Only my own file changed (`tasks/<lecture>/<slug>/submissions/<username>.py`, or my survey response).
+- [ ] The PR title follows the rule for this kind of PR (`<lecture>/<slug>: <username>` for a task, `survey: <username>` for a survey).
+- [ ] I ran the checker locally and it passed: `uv run python scripts/tasks.py check tasks/<lecture>/<slug> <username>`.

--- a/docs/participation-workflow.md
+++ b/docs/participation-workflow.md
@@ -142,7 +142,7 @@ still L05), and zero-padding keeps them sorted.
 
 | Lecture labels (blue) | Type labels |
 | --- | --- |
-| `l01-tokenization`, `l02-ngram`, `l03-embeddings`, `l04-attention`, `l05-makeup`, `l06-transformer`, `l07-pretraining`, `l08-data`, `l09-scaling`, `l10-evaluation`, `l11-sft`, `l12-alignment`, `l13-rag`, `l14-inference`, `l15-diffusion`, `l16-agents` | `task` (student exercise, many submissions), `help wanted` (one student, improves the repo), `bug`, `figure`, `survey`, `prep` (teaching team's own lecture preparation, e.g. #39), `project`, `not-done` |
+| `l01-tokenization`, `l02-ngram`, `l03-embeddings`, `l04-attention`, `l05-makeup`, `l06-transformer`, `l07-pretraining`, `l08-data`, `l09-scaling`, `l10-evaluation`, `l11-sft`, `l12-alignment`, `l13-rag`, `l14-inference`, `l15-diffusion`, `l16-agents` | `task` (student exercise, many submissions), `proposal` (a task suggested by a student through the issue form; relabelled `task` when accepted), `help wanted` (one student, improves the repo), `bug`, `figure`, `survey`, `prep` (teaching team's own lecture preparation, e.g. #39), `project`, `not-done` |
 
 | Item | Rule | Example |
 | --- | --- | --- |
@@ -154,6 +154,10 @@ still L05), and zero-padding keeps them sorted.
 | PR body | `Related to #<issue>` | `Related to #45` |
 | Branch in the fork | `<lecture label>-<slug>` | `l02-ngram-bigram-perplexity` |
 | Deadline | Tuesday 23:59 (Asia/Shanghai) of the same week | — |
+
+Students can propose tasks and report problems through the issue forms
+(**New issue** → *Propose a task* or *Report a problem in course material*).
+An accepted proposal is credited in the task's `instruction.md`.
 
 Privacy: GitHub username only, no real names or student IDs; the same rule as
 the survey. Assignments A1–A3 stay on the private channel because their


### PR DESCRIPTION
Students can propose tasks and report problems through GitHub issue forms:

- **Propose a task** (`.github/ISSUE_TEMPLATE/propose-task.yml`): lecture label (dropdown), goal, what a student submits, two examples, why it matters, difficulty. Labelled `proposal`; relabel `task` when accepted and credit the proposer in the task's `instruction.md`.
- **Report a problem in course material** (`course-material-problem.yml`): where, what is wrong, and whether the reporter wants to fix it. Labelled `bug`.
- `config.yml` keeps blank issues enabled and links the workflow page.
- `.github/pull_request_template.md`: `Related to #N` plus the three checkboxes (only my file changed, title rule, checker passed).

The `proposal` label is created on GitHub. `docs/participation-workflow.md` mentions the forms and the label. YAML validated with PyYAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LvnWe7Tmic9MjdL3b2oQK
