### PR TITLE
Add the student progress board

### DIFF
--- a/assets/translations.js
+++ b/assets/translations.js
@@ -67,6 +67,8 @@ window.courseTranslations = {
   "Exercise:": "练习：",
   "Papers:": "论文：",
   "Survey results:": "问卷结果：",
+  "Weekly tasks": "每周任务",
+  "Progress board": "进度榜",
   "Which LLM apps do you use most?": "你最常使用哪些 LLM 应用？",
   "counts": "统计表",
   "Before opening local slides or notebooks, run": "打开本地课件或笔记本前，请先运行",

--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
 </section>
 <section id="schedule">
   <h2>Weekly schedule</h2>
-  <p><span>Before opening local slides or notebooks, run</span> <code>uv sync</code>, <span>then</span> <code>uv run python scripts/slides.py serve</code>.</p>
+  <p><span>Before opening local slides or notebooks, run</span> <code>uv sync</code>, <span>then</span> <code>uv run python scripts/slides.py serve</code>. <a href="https://github.com/baojian/llm-26-fall/tree/main/tasks" target="_blank" rel="noopener noreferrer">Weekly tasks</a> · <a href="https://github.com/baojian/llm-26-fall/blob/main/tasks/PROGRESS.md" target="_blank" rel="noopener noreferrer">Progress board</a></p>
   <div class="table-wrap"><table id="week-table">
     <thead><tr><th scope="col">Week</th><th scope="col">Date</th><th scope="col">Topic and question</th><th scope="col">Content and materials</th><th scope="col">Milestone</th></tr></thead>
     <tbody>

--- a/scripts/progress.py
+++ b/scripts/progress.py
@@ -1,0 +1,207 @@
+"""Build the student progress board from merged task submissions.
+
+Runs every task's checker, reads the survey responses, optionally counts
+merged pull requests through ``gh``, and writes ``tasks/PROGRESS.md`` and
+``tasks/progress.svg``. Usernames listed in ``tasks/.progress-optout`` are left
+off the board.
+
+    uv run python scripts/progress.py             # with merged-PR counts from GitHub
+    uv run python scripts/progress.py --no-github  # offline
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import tasks as task_tools  # noqa: E402
+
+TASKS = ROOT / "tasks"
+SURVEY_RESPONSES = ROOT / "surveys/lecture-01/responses"
+REPO = "baojian/llm-26-fall"
+BADGES = [
+    ("🥇", "first merged PR", lambda s: (s.merged_prs or 0) >= 1 or s.submitted >= 1 or s.survey),
+    ("🔥", "5 tasks passed", lambda s: s.passed >= 5),
+    ("🏆", "10 tasks passed", lambda s: s.passed >= 10),
+    ("🎯", "all correct (3+ tasks)", lambda s: s.submitted >= 3 and s.passed == s.submitted),
+    ("💡", "proposal accepted", lambda s: s.proposals >= 1),
+]
+
+
+@dataclass
+class Student:
+    username: str
+    submitted: int = 0
+    passed: int = 0
+    lectures: set = field(default_factory=set)
+    survey: bool = False
+    proposals: int = 0
+    merged_prs: int | None = None
+
+    @property
+    def correct_rate(self) -> float | None:
+        return self.passed / self.submitted if self.submitted else None
+
+    @property
+    def participation(self) -> int:
+        return len(self.lectures) + (1 if self.survey else 0)
+
+    def badges(self) -> str:
+        return " ".join(icon for icon, _, earned in BADGES if earned(self))
+
+
+def checker_results(folder: Path) -> dict[str, bool]:
+    """Run one task's checker; return {username: all tests passed}."""
+    usernames = task_tools.submissions(folder)
+    if not usernames:
+        return {}
+    with tempfile.TemporaryDirectory() as tmp:
+        report = Path(tmp) / "report.xml"
+        subprocess.run([sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", str(folder / "tests"),
+                        f"--junitxml={report}"], cwd=ROOT, capture_output=True, text=True)
+        outcomes: dict[str, bool] = {user: True for user in usernames}
+        if not report.exists():
+            return {user: False for user in usernames}
+        for case in ET.parse(report).getroot().iter("testcase"):
+            name = case.get("name", "")
+            if "[" not in name or "@" not in name:
+                continue
+            user = name[name.rindex("@") + 1:].rstrip("]")
+            if user in outcomes and any(child.tag in {"failure", "error"} for child in case):
+                outcomes[user] = False
+    return outcomes
+
+
+def merged_pr_counts(repo: str = REPO) -> dict[str, int] | None:
+    """Merged PRs per author (lowercase login) via gh; None when gh is unavailable."""
+    try:
+        output = subprocess.run(["gh", "pr", "list", "--repo", repo, "--state", "merged", "--limit", "1000",
+                                 "--json", "author"], capture_output=True, text=True, check=True).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    counts: dict[str, int] = defaultdict(int)
+    for pr in json.loads(output):
+        counts[pr["author"]["login"].lower()] += 1
+    return dict(counts)
+
+
+def collect(tasks_root: Path = TASKS, survey_dir: Path = SURVEY_RESPONSES,
+            prs: dict[str, int] | None = None) -> list[Student]:
+    students: dict[str, Student] = {}
+
+    def get(user: str) -> Student:
+        return students.setdefault(user, Student(user))
+
+    for folder in task_tools.task_folders(tasks_root):
+        info = task_tools.manifest(folder)["task"]
+        for user, ok in checker_results(folder).items():
+            student = get(user)
+            student.submitted += 1
+            student.passed += ok
+            student.lectures.add(info["lecture"])
+        for user in info.get("proposed_by", "").split(","):
+            if user.strip():
+                get(user.strip().lower()).proposals += 1
+    if survey_dir.exists():
+        for path in survey_dir.glob("*.md"):
+            get(path.stem.lower()).survey = True
+    if prs is not None:
+        for user, count in prs.items():
+            if user in students:
+                students[user].merged_prs = count
+        for student in students.values():
+            student.merged_prs = student.merged_prs or 0
+    optout = tasks_root / ".progress-optout"
+    hidden = {word for line in optout.read_text().splitlines() if not line.startswith("#") for word in line.split()} if optout.exists() else set()
+    board = [s for s in students.values() if s.username not in hidden]
+    return sorted(board, key=lambda s: (-s.passed, -(s.correct_rate or 0), -s.participation, s.username))
+
+
+def board_markdown(students: list[Student], today: dt.date, github: bool) -> str:
+    rows = ["| # | Student | Tasks passed | Correct rate | Participation | Merged PRs | Badges |",
+            "| ---: | :--- | ---: | ---: | ---: | ---: | :--- |"]
+    for rank, s in enumerate(students, 1):
+        rate = "—" if s.correct_rate is None else f"{s.correct_rate:.0%}"
+        prs = "—" if s.merged_prs is None else str(s.merged_prs)
+        link = f"[{s.username}](https://github.com/{REPO}/pulls?q=is%3Apr+is%3Amerged+author%3A{s.username})"
+        rows.append(f"| {rank} | {link} | {s.passed} | {rate} | {s.participation} | {prs} | {s.badges()} |")
+    legend = " · ".join(f"{icon} {text}" for icon, text, _ in BADGES)
+    pr_note = "" if github else " Merged-PR counts were not fetched in this run."
+    return f"""# Progress board
+
+Generated on {today:%B %-d, %Y} from the merged files in this repository.{pr_note}
+Click a username to see that student's merged pull requests.
+
+![Bar chart of tasks passed per student](progress.svg)
+
+{chr(10).join(rows)}
+
+**Columns.** *Tasks passed*: submissions whose checker passes. *Correct rate*:
+passed ÷ submitted. *Participation*: lectures with at least one submission,
+plus one for the Lecture 01 survey. *Merged PRs*: all pull requests merged
+into this repository, including fixes and proposals.
+
+**Badges.** {legend}.
+
+To be left off this board, add your username to `tasks/.progress-optout`.
+Regenerate with `uv run python scripts/progress.py`.
+"""
+
+
+def board_svg(students: list[Student], today: dt.date, limit: int = 25) -> str:
+    shown = [s for s in students if s.passed or s.submitted][:limit] or students[:limit]
+    left, top, width, row, bar = 220, 84, 960, 34, 22
+    plot_width = width - left - 80
+    height = top + row * max(len(shown), 1) + 60
+    largest = max((s.passed for s in shown), default=0) or 1
+    ink, muted, accent, grid, paper = "#202b38", "#566471", "#20578c", "#dce2e7", "#fbfbf9"
+    parts = [f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" '
+             f'role="img" aria-labelledby="t" font-family="Arial, Helvetica Neue, PingFang SC, sans-serif">',
+             '<title id="t">Tasks passed per student</title>',
+             f'<rect width="{width}" height="{height}" fill="{paper}"/>',
+             f'<text x="32" y="40" font-size="24" font-weight="700" fill="{ink}">Tasks passed per student</text>',
+             f'<text x="32" y="64" font-size="15" fill="{muted}">{escape(f"{len(students)} students on the board · generated {today:%B %-d, %Y}")}</text>']
+    for tick in range(0, largest + 1, max(1, largest // 8)):
+        x = left + plot_width * tick / largest
+        parts.append(f'<line x1="{x:.1f}" y1="{top - 6}" x2="{x:.1f}" y2="{top + row * len(shown)}" stroke="{grid}"/>')
+        parts.append(f'<text x="{x:.1f}" y="{top + row * len(shown) + 20}" font-size="13" fill="{muted}" text-anchor="middle">{tick}</text>')
+    for index, s in enumerate(shown):
+        y = top + row * index
+        w = plot_width * s.passed / largest
+        parts.append(f'<text x="{left - 12}" y="{y + bar / 2 + 5}" font-size="15" fill="{ink}" text-anchor="end">{escape(s.username)}</text>')
+        if s.passed:
+            parts.append(f'<rect x="{left}" y="{y}" width="{w:.1f}" height="{bar}" rx="4" fill="{accent}"/>')
+        parts.append(f'<text x="{left + w + 8:.1f}" y="{y + bar / 2 + 5}" font-size="14" fill="{ink}">{s.passed}</text>')
+    parts.append("</svg>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--no-github", action="store_true", help="skip the merged-PR count")
+    parser.add_argument("--date", type=dt.date.fromisoformat, default=dt.date.today())
+    args = parser.parse_args()
+    prs = None if args.no_github else merged_pr_counts()
+    students = collect(prs=prs)
+    (TASKS / "PROGRESS.md").write_text(board_markdown(students, args.date, prs is not None), encoding="utf-8")
+    (TASKS / "progress.svg").write_text(board_svg(students, args.date), encoding="utf-8")
+    for s in students[:10]:
+        print(f"{s.passed:3d} passed / {s.submitted} submitted  {s.username}  {s.badges()}")
+    print(f"{len(students)} students -> {TASKS / 'PROGRESS.md'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/surveys/lecture-01/README.md
+++ b/surveys/lecture-01/README.md
@@ -15,17 +15,17 @@ ID is needed. Share only app names you are comfortable making public.
 
 <!-- survey-results:start -->
 Counted from the merged files in [responses/](responses/) on September 11, 2026:
-**24 responses**, at most two selections each. 2 responses selected more than 2 apps and are not counted.
+**26 responses**, at most two selections each. 2 responses selected more than 2 apps and are not counted.
 
 ![Bar chart of the number of students who selected each LLM app](results.svg)
 
 | App | Students |
 | :--- | ---: |
-| ChatGPT | 20 |
-| DeepSeek | 12 |
+| ChatGPT | 22 |
+| DeepSeek | 13 |
 | Gemini | 4 |
+| Doubao (豆包) | 4 |
 | Claude | 3 |
-| Doubao (豆包) | 3 |
 | Kimi | 1 |
 | Qwen (千问) | 0 |
 | Tencent Yuanbao (腾讯元宝) | 0 |

--- a/surveys/lecture-01/results.svg
+++ b/surveys/lecture-01/results.svg
@@ -1,49 +1,37 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="556" viewBox="0 0 960 556" role="img" aria-labelledby="chart-title chart-desc" font-family="Arial, Helvetica Neue, PingFang SC, Microsoft YaHei, sans-serif">
 <title id="chart-title">Which LLM apps do you use most?</title>
-<desc id="chart-desc">ChatGPT: 20; DeepSeek: 12; Gemini: 4; Claude: 3; Doubao (豆包): 3; Kimi: 1; Qwen (千问): 0; Tencent Yuanbao (腾讯元宝): 0; Zhipu Qingyan (智谱清言): 0</desc>
+<desc id="chart-desc">ChatGPT: 22; DeepSeek: 13; Gemini: 4; Doubao (豆包): 4; Claude: 3; Kimi: 1; Qwen (千问): 0; Tencent Yuanbao (腾讯元宝): 0; Zhipu Qingyan (智谱清言): 0</desc>
 <rect width="960" height="556" fill="#fbfbf9"/>
 <text x="32" y="44" font-size="26" font-weight="700" fill="#202b38">Which LLM apps do you use most?</text>
-<text x="32" y="72" font-size="17" fill="#566471">Lecture 01 survey · 24 responses · counted September 11, 2026</text>
+<text x="32" y="72" font-size="17" fill="#566471">Lecture 01 survey · 26 responses · counted September 11, 2026</text>
 <line x1="250.0" y1="88" x2="250.0" y2="492" stroke="#dce2e7" stroke-width="1"/>
 <text x="250.0" y="516" font-size="15" fill="#566471" text-anchor="middle">0</text>
-<line x1="312.0" y1="88" x2="312.0" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="312.0" y="516" font-size="15" fill="#566471" text-anchor="middle">2</text>
-<line x1="374.0" y1="88" x2="374.0" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="374.0" y="516" font-size="15" fill="#566471" text-anchor="middle">4</text>
-<line x1="436.0" y1="88" x2="436.0" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="436.0" y="516" font-size="15" fill="#566471" text-anchor="middle">6</text>
-<line x1="498.0" y1="88" x2="498.0" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="498.0" y="516" font-size="15" fill="#566471" text-anchor="middle">8</text>
-<line x1="560.0" y1="88" x2="560.0" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="560.0" y="516" font-size="15" fill="#566471" text-anchor="middle">10</text>
-<line x1="622.0" y1="88" x2="622.0" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="622.0" y="516" font-size="15" fill="#566471" text-anchor="middle">12</text>
-<line x1="684.0" y1="88" x2="684.0" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="684.0" y="516" font-size="15" fill="#566471" text-anchor="middle">14</text>
-<line x1="746.0" y1="88" x2="746.0" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="746.0" y="516" font-size="15" fill="#566471" text-anchor="middle">16</text>
-<line x1="808.0" y1="88" x2="808.0" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="808.0" y="516" font-size="15" fill="#566471" text-anchor="middle">18</text>
-<line x1="870.0" y1="88" x2="870.0" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="870.0" y="516" font-size="15" fill="#566471" text-anchor="middle">20</text>
+<line x1="390.9" y1="88" x2="390.9" y2="492" stroke="#dce2e7" stroke-width="1"/>
+<text x="390.9" y="516" font-size="15" fill="#566471" text-anchor="middle">5</text>
+<line x1="531.8" y1="88" x2="531.8" y2="492" stroke="#dce2e7" stroke-width="1"/>
+<text x="531.8" y="516" font-size="15" fill="#566471" text-anchor="middle">10</text>
+<line x1="672.7" y1="88" x2="672.7" y2="492" stroke="#dce2e7" stroke-width="1"/>
+<text x="672.7" y="516" font-size="15" fill="#566471" text-anchor="middle">15</text>
+<line x1="813.6" y1="88" x2="813.6" y2="492" stroke="#dce2e7" stroke-width="1"/>
+<text x="813.6" y="516" font-size="15" fill="#566471" text-anchor="middle">20</text>
 <text x="236" y="116.0" font-size="17" fill="#202b38" text-anchor="end">ChatGPT</text>
 <rect x="250" y="96" width="620.0" height="28" rx="4" fill="#20578c"/>
-<text x="880.0" y="116.0" font-size="16" fill="#202b38">20</text>
+<text x="880.0" y="116.0" font-size="16" fill="#202b38">22</text>
 <text x="236" y="160.0" font-size="17" fill="#202b38" text-anchor="end">DeepSeek</text>
-<rect x="250" y="140" width="372.0" height="28" rx="4" fill="#20578c"/>
-<text x="632.0" y="160.0" font-size="16" fill="#202b38">12</text>
+<rect x="250" y="140" width="366.4" height="28" rx="4" fill="#20578c"/>
+<text x="626.4" y="160.0" font-size="16" fill="#202b38">13</text>
 <text x="236" y="204.0" font-size="17" fill="#202b38" text-anchor="end">Gemini</text>
-<rect x="250" y="184" width="124.0" height="28" rx="4" fill="#20578c"/>
-<text x="384.0" y="204.0" font-size="16" fill="#202b38">4</text>
-<text x="236" y="248.0" font-size="17" fill="#202b38" text-anchor="end">Claude</text>
-<rect x="250" y="228" width="93.0" height="28" rx="4" fill="#20578c"/>
-<text x="353.0" y="248.0" font-size="16" fill="#202b38">3</text>
-<text x="236" y="292.0" font-size="17" fill="#202b38" text-anchor="end">Doubao (豆包)</text>
-<rect x="250" y="272" width="93.0" height="28" rx="4" fill="#20578c"/>
-<text x="353.0" y="292.0" font-size="16" fill="#202b38">3</text>
+<rect x="250" y="184" width="112.7" height="28" rx="4" fill="#20578c"/>
+<text x="372.7" y="204.0" font-size="16" fill="#202b38">4</text>
+<text x="236" y="248.0" font-size="17" fill="#202b38" text-anchor="end">Doubao (豆包)</text>
+<rect x="250" y="228" width="112.7" height="28" rx="4" fill="#20578c"/>
+<text x="372.7" y="248.0" font-size="16" fill="#202b38">4</text>
+<text x="236" y="292.0" font-size="17" fill="#202b38" text-anchor="end">Claude</text>
+<rect x="250" y="272" width="84.5" height="28" rx="4" fill="#20578c"/>
+<text x="344.5" y="292.0" font-size="16" fill="#202b38">3</text>
 <text x="236" y="336.0" font-size="17" fill="#202b38" text-anchor="end">Kimi</text>
-<rect x="250" y="316" width="31.0" height="28" rx="4" fill="#20578c"/>
-<text x="291.0" y="336.0" font-size="16" fill="#202b38">1</text>
+<rect x="250" y="316" width="28.2" height="28" rx="4" fill="#20578c"/>
+<text x="288.2" y="336.0" font-size="16" fill="#202b38">1</text>
 <text x="236" y="380.0" font-size="17" fill="#202b38" text-anchor="end">Qwen (千问)</text>
 <text x="260.0" y="380.0" font-size="16" fill="#202b38">0</text>
 <text x="236" y="424.0" font-size="17" fill="#202b38" text-anchor="end">Tencent Yuanbao (腾讯元宝)</text>

--- a/tasks/.progress-optout
+++ b/tasks/.progress-optout
@@ -1,0 +1,2 @@
+# Usernames to leave off tasks/PROGRESS.md, one per line. Lines starting with # are comments.
+octocat

--- a/tasks/PROGRESS.md
+++ b/tasks/PROGRESS.md
@@ -1,0 +1,47 @@
+# Progress board
+
+Generated on September 11, 2026 from the merged files in this repository.
+Click a username to see that student's merged pull requests.
+
+![Bar chart of tasks passed per student](progress.svg)
+
+| # | Student | Tasks passed | Correct rate | Participation | Merged PRs | Badges |
+| ---: | :--- | ---: | ---: | ---: | ---: | :--- |
+| 1 | [760zhang](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3A760zhang) | 0 | — | 1 | 1 | 🥇 |
+| 2 | [d-shy](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ad-shy) | 0 | — | 1 | 1 | 🥇 |
+| 3 | [dinghouqin](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Adinghouqin) | 0 | — | 1 | 1 | 🥇 |
+| 4 | [e1vax](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ae1vax) | 0 | — | 1 | 1 | 🥇 |
+| 5 | [eric15342335](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Aeric15342335) | 0 | — | 1 | 1 | 🥇 |
+| 6 | [garyagasa](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Agaryagasa) | 0 | — | 1 | 1 | 🥇 |
+| 7 | [garyguan2419](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Agaryguan2419) | 0 | — | 1 | 1 | 🥇 |
+| 8 | [geekeraman](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ageekeraman) | 0 | — | 1 | 1 | 🥇 |
+| 9 | [gxj230958](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Agxj230958) | 0 | — | 1 | 1 | 🥇 |
+| 10 | [harmonyhhh66](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Aharmonyhhh66) | 0 | — | 1 | 1 | 🥇 |
+| 11 | [huangz065](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ahuangz065) | 0 | — | 1 | 1 | 🥇 |
+| 12 | [huuob](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ahuuob) | 0 | — | 1 | 1 | 🥇 |
+| 13 | [jckinpku](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ajckinpku) | 0 | — | 1 | 1 | 🥇 |
+| 14 | [jdjxhll](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ajdjxhll) | 0 | — | 1 | 1 | 🥇 |
+| 15 | [liuyglucky](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Aliuyglucky) | 0 | — | 1 | 1 | 🥇 |
+| 16 | [lllusia](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Alllusia) | 0 | — | 1 | 1 | 🥇 |
+| 17 | [moonlightafar](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Amoonlightafar) | 0 | — | 1 | 1 | 🥇 |
+| 18 | [naonaozhong](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Anaonaozhong) | 0 | — | 1 | 1 | 🥇 |
+| 19 | [nashknight](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Anashknight) | 0 | — | 1 | 1 | 🥇 |
+| 20 | [steven9912](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Asteven9912) | 0 | — | 1 | 1 | 🥇 |
+| 21 | [still-fantasy-star](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Astill-fantasy-star) | 0 | — | 1 | 1 | 🥇 |
+| 22 | [wangzj1020](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Awangzj1020) | 0 | — | 1 | 1 | 🥇 |
+| 23 | [wsqusaqi537](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Awsqusaqi537) | 0 | — | 1 | 1 | 🥇 |
+| 24 | [xpxpz](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Axpxpz) | 0 | — | 1 | 1 | 🥇 |
+| 25 | [yanghongpeng8-rgb](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ayanghongpeng8-rgb) | 0 | — | 1 | 1 | 🥇 |
+| 26 | [yannickchen77](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ayannickchen77) | 0 | — | 1 | 1 | 🥇 |
+| 27 | [yunlangli-shtj](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ayunlangli-shtj) | 0 | — | 1 | 1 | 🥇 |
+| 28 | [zifangchu](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Azifangchu) | 0 | — | 1 | 1 | 🥇 |
+
+**Columns.** *Tasks passed*: submissions whose checker passes. *Correct rate*:
+passed ÷ submitted. *Participation*: lectures with at least one submission,
+plus one for the Lecture 01 survey. *Merged PRs*: all pull requests merged
+into this repository, including fixes and proposals.
+
+**Badges.** 🥇 first merged PR · 🔥 5 tasks passed · 🏆 10 tasks passed · 🎯 all correct (3+ tasks) · 💡 proposal accepted.
+
+To be left off this board, add your username to `tasks/.progress-optout`.
+Regenerate with `uv run python scripts/progress.py`.

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -17,6 +17,10 @@ tasks/
     submissions/<username>.py    one file per student
 ```
 
+[PROGRESS.md](PROGRESS.md) is the class progress board: tasks passed,
+correct rate, participation, merged PRs, and badges per student. It is
+regenerated after each merge batch with `uv run python scripts/progress.py`.
+
 Task issues on GitHub carry the same lecture label as the folder
 (`l02-ngram`, `l03-embeddings`, …) plus the type label `task`. The full
 rules, timeline, and labels are in

--- a/tasks/TEMPLATE/task.toml
+++ b/tasks/TEMPLATE/task.toml
@@ -9,6 +9,7 @@ difficulty = "easy"                  # easy | medium | hard
 time_minutes = 45                    # typical time for a student
 deadline = "2026-09-22T23:59:00+08:00"
 issue = 0                            # GitHub issue number once opened
+proposed_by = ""                     # GitHub username of a student whose proposal became this task
 
 [submission]
 file = "submissions/<username>.py"   # exactly one file per student

--- a/tasks/TEMPLATE/tests/test_task.py
+++ b/tasks/TEMPLATE/tests/test_task.py
@@ -26,12 +26,12 @@ def load(path):
     return getattr(module, FUNCTION)
 
 
-@pytest.mark.parametrize("submission", SUBMISSIONS, ids=[p.stem for p in SUBMISSIONS])
+@pytest.mark.parametrize("submission", SUBMISSIONS, ids=[f"@{p.stem}" for p in SUBMISSIONS])
 def test_filename_is_a_lowercase_username(submission):
     assert submission.stem == submission.stem.lower(), "name the file <username>.py in lowercase"
 
 
-@pytest.mark.parametrize("submission", SUBMISSIONS, ids=[p.stem for p in SUBMISSIONS])
+@pytest.mark.parametrize("submission", SUBMISSIONS, ids=[f"@{p.stem}" for p in SUBMISSIONS])
 @pytest.mark.parametrize("text,expected", CASES)
 def test_cases(submission, text, expected):
     assert load(submission)(text) == expected

--- a/tasks/example/word-count/task.toml
+++ b/tasks/example/word-count/task.toml
@@ -9,6 +9,7 @@ difficulty = "easy"
 time_minutes = 20
 deadline = "2026-12-31T23:59:00+08:00"
 issue = 0
+proposed_by = ""
 
 [submission]
 file = "submissions/<username>.py"

--- a/tasks/example/word-count/tests/test_task.py
+++ b/tasks/example/word-count/tests/test_task.py
@@ -28,12 +28,12 @@ def load(path):
     return getattr(module, FUNCTION)
 
 
-@pytest.mark.parametrize("submission", SUBMISSIONS, ids=[p.stem for p in SUBMISSIONS])
+@pytest.mark.parametrize("submission", SUBMISSIONS, ids=[f"@{p.stem}" for p in SUBMISSIONS])
 def test_filename_is_a_lowercase_username(submission):
     assert submission.stem == submission.stem.lower(), "name the file <username>.py in lowercase"
 
 
-@pytest.mark.parametrize("submission", SUBMISSIONS, ids=[p.stem for p in SUBMISSIONS])
+@pytest.mark.parametrize("submission", SUBMISSIONS, ids=[f"@{p.stem}" for p in SUBMISSIONS])
 @pytest.mark.parametrize("text,expected", CASES)
 def test_cases(submission, text, expected):
     assert load(submission)(text) == expected

--- a/tasks/progress.svg
+++ b/tasks/progress.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="994" viewBox="0 0 960 994" role="img" aria-labelledby="t" font-family="Arial, Helvetica Neue, PingFang SC, sans-serif">
+<title id="t">Tasks passed per student</title>
+<rect width="960" height="994" fill="#fbfbf9"/>
+<text x="32" y="40" font-size="24" font-weight="700" fill="#202b38">Tasks passed per student</text>
+<text x="32" y="64" font-size="15" fill="#566471">28 students on the board · generated September 11, 2026</text>
+<line x1="220.0" y1="78" x2="220.0" y2="934" stroke="#dce2e7"/>
+<text x="220.0" y="954" font-size="13" fill="#566471" text-anchor="middle">0</text>
+<line x1="880.0" y1="78" x2="880.0" y2="934" stroke="#dce2e7"/>
+<text x="880.0" y="954" font-size="13" fill="#566471" text-anchor="middle">1</text>
+<text x="208" y="100.0" font-size="15" fill="#202b38" text-anchor="end">760zhang</text>
+<text x="228.0" y="100.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="134.0" font-size="15" fill="#202b38" text-anchor="end">d-shy</text>
+<text x="228.0" y="134.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="168.0" font-size="15" fill="#202b38" text-anchor="end">dinghouqin</text>
+<text x="228.0" y="168.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="202.0" font-size="15" fill="#202b38" text-anchor="end">e1vax</text>
+<text x="228.0" y="202.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="236.0" font-size="15" fill="#202b38" text-anchor="end">eric15342335</text>
+<text x="228.0" y="236.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="270.0" font-size="15" fill="#202b38" text-anchor="end">garyagasa</text>
+<text x="228.0" y="270.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="304.0" font-size="15" fill="#202b38" text-anchor="end">garyguan2419</text>
+<text x="228.0" y="304.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="338.0" font-size="15" fill="#202b38" text-anchor="end">geekeraman</text>
+<text x="228.0" y="338.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="372.0" font-size="15" fill="#202b38" text-anchor="end">gxj230958</text>
+<text x="228.0" y="372.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="406.0" font-size="15" fill="#202b38" text-anchor="end">harmonyhhh66</text>
+<text x="228.0" y="406.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="440.0" font-size="15" fill="#202b38" text-anchor="end">huangz065</text>
+<text x="228.0" y="440.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="474.0" font-size="15" fill="#202b38" text-anchor="end">huuob</text>
+<text x="228.0" y="474.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="508.0" font-size="15" fill="#202b38" text-anchor="end">jckinpku</text>
+<text x="228.0" y="508.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="542.0" font-size="15" fill="#202b38" text-anchor="end">jdjxhll</text>
+<text x="228.0" y="542.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="576.0" font-size="15" fill="#202b38" text-anchor="end">liuyglucky</text>
+<text x="228.0" y="576.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="610.0" font-size="15" fill="#202b38" text-anchor="end">lllusia</text>
+<text x="228.0" y="610.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="644.0" font-size="15" fill="#202b38" text-anchor="end">moonlightafar</text>
+<text x="228.0" y="644.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="678.0" font-size="15" fill="#202b38" text-anchor="end">naonaozhong</text>
+<text x="228.0" y="678.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="712.0" font-size="15" fill="#202b38" text-anchor="end">nashknight</text>
+<text x="228.0" y="712.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="746.0" font-size="15" fill="#202b38" text-anchor="end">steven9912</text>
+<text x="228.0" y="746.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="780.0" font-size="15" fill="#202b38" text-anchor="end">still-fantasy-star</text>
+<text x="228.0" y="780.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="814.0" font-size="15" fill="#202b38" text-anchor="end">wangzj1020</text>
+<text x="228.0" y="814.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="848.0" font-size="15" fill="#202b38" text-anchor="end">wsqusaqi537</text>
+<text x="228.0" y="848.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="882.0" font-size="15" fill="#202b38" text-anchor="end">xpxpz</text>
+<text x="228.0" y="882.0" font-size="14" fill="#202b38">0</text>
+<text x="208" y="916.0" font-size="15" fill="#202b38" text-anchor="end">yanghongpeng8-rgb</text>
+<text x="228.0" y="916.0" font-size="14" fill="#202b38">0</text>
+</svg>

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,63 @@
+"""Check the progress board builder on a temporary tasks tree and on the committed board."""
+
+import datetime as dt
+import shutil
+from pathlib import Path
+
+from scripts import progress, tasks
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def make_tree(tmp_path):
+    tasks_root = tmp_path / "tasks"
+    shutil.copytree(ROOT / "tasks/TEMPLATE", tasks_root / "TEMPLATE")
+    shutil.copytree(ROOT / "tasks/example", tasks_root / "example")
+    demo = tasks.create_task("l02-ngram", "demo", "Demo", tasks_root)
+    (demo / "task.toml").write_text((demo / "task.toml").read_text().replace('proposed_by = ""', 'proposed_by = "alice"'))
+    (demo / "submissions/alice.py").write_text("def solve(text):\n    return ['REPLACE'] if text else []\n")
+    (demo / "submissions/bob-x.py").write_text("def solve(text):\n    return []\n")
+    (demo / "submissions/carol.py").write_text("def solve(text):\n    return ['REPLACE'] if text else []\n")
+    survey = tmp_path / "responses"
+    survey.mkdir()
+    (survey / "Alice.md").write_text("GitHub username: Alice\n")
+    (survey / "dave.md").write_text("GitHub username: dave\n")
+    return tasks_root, survey
+
+
+def test_collect_counts_passes_participation_and_badges(tmp_path):
+    tasks_root, survey = make_tree(tmp_path)
+    (tasks_root / ".progress-optout").write_text("# hidden\ncarol\n")
+    board = progress.collect(tasks_root, survey, prs={"alice": 3, "bob-x": 1, "octocat": 0})
+    by_name = {s.username: s for s in board}
+    assert [s.username for s in board] == ["alice", "octocat", "bob-x", "dave"]
+    assert "carol" not in by_name
+    alice = by_name["alice"]
+    assert (alice.submitted, alice.passed, alice.correct_rate, alice.participation) == (1, 1, 1.0, 2)
+    assert alice.proposals == 1 and alice.merged_prs == 3 and "💡" in alice.badges()
+    bob = by_name["bob-x"]
+    assert (bob.submitted, bob.passed, bob.correct_rate) == (1, 0, 0.0)
+    assert by_name["octocat"].passed == 1 and by_name["octocat"].lectures == {"example"}
+    assert by_name["dave"].submitted == 0 and by_name["dave"].survey and by_name["dave"].merged_prs == 0
+
+
+def test_markdown_and_svg_render(tmp_path):
+    tasks_root, survey = make_tree(tmp_path)
+    board = progress.collect(tasks_root, survey, prs=None)
+    text = progress.board_markdown(board, dt.date(2026, 9, 16), github=False)
+    assert "| 1 | [alice](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Aalice) | 1 | 100% | 2 | — |" in text
+    assert "Merged-PR counts were not fetched" in text
+    svg = progress.board_svg(board, dt.date(2026, 9, 16))
+    assert svg.startswith("<svg") and svg.count("<rect") == 1 + sum(1 for s in board if s.passed)
+
+
+def test_committed_board_lists_every_survey_and_task_participant():
+    text = (ROOT / "tasks/PROGRESS.md").read_text(encoding="utf-8")
+    usernames = {p.stem.lower() for p in (ROOT / "surveys/lecture-01/responses").glob("*.md")}
+    for folder in tasks.task_folders():
+        usernames.update(tasks.submissions(folder))
+    optout = ROOT / "tasks/.progress-optout"
+    usernames -= {w for line in optout.read_text().splitlines() if not line.startswith("#") for w in line.split()}
+    for user in usernames:
+        assert f"[{user}](" in text, f"{user} is missing from tasks/PROGRESS.md; rerun scripts/progress.py"
+    assert (ROOT / "tasks/progress.svg").read_text().startswith("<svg")

--- a/tests/test_tasks_tool.py
+++ b/tests/test_tasks_tool.py
@@ -58,8 +58,8 @@ def test_template_checker_rejects_uppercase_filenames_and_wrong_answers(tasks_ro
     result = subprocess.run([sys.executable, "-m", "pytest", "-q", str(folder / "tests")], cwd=ROOT,
                             capture_output=True, text=True)
     assert result.returncode != 0
-    assert "test_filename_is_a_lowercase_username[Octocat]" in result.stdout
-    assert "test_cases[REPLACE-expected0-wrong]" in result.stdout
+    assert "test_filename_is_a_lowercase_username[@Octocat]" in result.stdout
+    assert "test_cases[REPLACE-expected0-@wrong]" in result.stdout
     assert "2 failed, 4 passed" in result.stdout
 
 


### PR DESCRIPTION
A per-student progress board so students can see what they have done.

**`tasks/PROGRESS.md`** (with `tasks/progress.svg`), one row per student, ranked by tasks passed, then correct rate, then participation:

| Column | Source |
| --- | --- |
| Tasks passed | every task's checker, run on the student's submission |
| Correct rate | passed ÷ submitted |
| Participation | lectures with a submission, plus one for the Lecture 01 survey |
| Merged PRs | `gh pr list --state merged` per author |
| Badges | 🥇 first merged PR · 🔥 5 tasks · 🏆 10 tasks · 🎯 all correct (3+) · 💡 proposal accepted |

Each username links to that student's merged PRs on GitHub. `tasks/.progress-optout` hides listed usernames (the sample `octocat` is there). Regenerate after each merge batch:

```sh
uv run python scripts/progress.py          # or --no-github when offline
```

Also in this PR:
- Task checkers tag test ids with `@username`, so results attribute correctly to hyphenated usernames; `task.toml` gains `proposed_by` for the 💡 badge.
- The website's schedule intro links "Weekly tasks" and "Progress board" (Chinese strings added); the tasks README links the board.
- The survey chart is regenerated for the two survey PRs merged today (26 responses counted).

Verified: `uv run python -m pytest tests/` (106 passed), including a test that fails if the committed board is missing any participant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LvnWe7Tmic9MjdL3b2oQK
