### PR TITLE
refresh survey results and progress board after merging surveys #60-#64

### DIFF
--- a/scripts/survey_results.py
+++ b/scripts/survey_results.py
@@ -22,7 +22,7 @@ SURVEY = ROOT / "surveys/lecture-01"
 LISTED_APPS = ["ChatGPT", "Claude", "Gemini", "DeepSeek", "Doubao (豆包)", "Qwen (千问)",
                "Kimi", "Tencent Yuanbao (腾讯元宝)", "Zhipu Qingyan (智谱清言)"]
 MAX_CHOICES = 2
-CHECKED = re.compile(r"^- \[[xX]\] (.+?)\s*$", re.MULTILINE)
+CHECKED = re.compile(r"^- \[\s*[xX]\s*\] (.+?)\s*$", re.MULTILINE)
 
 
 def selections(text: str) -> list[str]:

--- a/surveys/lecture-01/README.md
+++ b/surveys/lecture-01/README.md
@@ -14,18 +14,18 @@ ID is needed. Share only app names you are comfortable making public.
 ## Results so far
 
 <!-- survey-results:start -->
-Counted from the merged files in [responses/](responses/) on September 11, 2026:
-**32 responses**, at most two selections each. 2 responses selected more than 2 apps and are not counted.
+Counted from the merged files in [responses/](responses/) on September 12, 2026:
+**37 responses**, at most two selections each. 2 responses selected more than 2 apps and are not counted.
 
 ![Bar chart of the number of students who selected each LLM app](results.svg)
 
 | App | Students |
 | :--- | ---: |
-| ChatGPT | 28 |
-| DeepSeek | 14 |
-| Doubao (豆包) | 5 |
+| ChatGPT | 32 |
+| DeepSeek | 17 |
+| Doubao (豆包) | 7 |
+| Claude | 4 |
 | Gemini | 4 |
-| Claude | 3 |
 | Kimi | 3 |
 | Qwen (千问) | 1 |
 | Zhipu Qingyan (智谱清言) | 1 |

--- a/surveys/lecture-01/results.svg
+++ b/surveys/lecture-01/results.svg
@@ -1,45 +1,47 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="556" viewBox="0 0 960 556" role="img" aria-labelledby="chart-title chart-desc" font-family="Arial, Helvetica Neue, PingFang SC, Microsoft YaHei, sans-serif">
 <title id="chart-title">Which LLM apps do you use most?</title>
-<desc id="chart-desc">ChatGPT: 28; DeepSeek: 14; Doubao (豆包): 5; Gemini: 4; Claude: 3; Kimi: 3; Qwen (千问): 1; Zhipu Qingyan (智谱清言): 1; Tencent Yuanbao (腾讯元宝): 0</desc>
+<desc id="chart-desc">ChatGPT: 32; DeepSeek: 17; Doubao (豆包): 7; Claude: 4; Gemini: 4; Kimi: 3; Qwen (千问): 1; Zhipu Qingyan (智谱清言): 1; Tencent Yuanbao (腾讯元宝): 0</desc>
 <rect width="960" height="556" fill="#fbfbf9"/>
 <text x="32" y="44" font-size="26" font-weight="700" fill="#202b38">Which LLM apps do you use most?</text>
-<text x="32" y="72" font-size="17" fill="#566471">Lecture 01 survey · 32 responses · counted September 11, 2026</text>
+<text x="32" y="72" font-size="17" fill="#566471">Lecture 01 survey · 37 responses · counted September 12, 2026</text>
 <line x1="250.0" y1="88" x2="250.0" y2="492" stroke="#dce2e7" stroke-width="1"/>
 <text x="250.0" y="516" font-size="15" fill="#566471" text-anchor="middle">0</text>
-<line x1="360.7" y1="88" x2="360.7" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="360.7" y="516" font-size="15" fill="#566471" text-anchor="middle">5</text>
-<line x1="471.4" y1="88" x2="471.4" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="471.4" y="516" font-size="15" fill="#566471" text-anchor="middle">10</text>
-<line x1="582.1" y1="88" x2="582.1" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="582.1" y="516" font-size="15" fill="#566471" text-anchor="middle">15</text>
-<line x1="692.9" y1="88" x2="692.9" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="692.9" y="516" font-size="15" fill="#566471" text-anchor="middle">20</text>
-<line x1="803.6" y1="88" x2="803.6" y2="492" stroke="#dce2e7" stroke-width="1"/>
-<text x="803.6" y="516" font-size="15" fill="#566471" text-anchor="middle">25</text>
+<line x1="346.9" y1="88" x2="346.9" y2="492" stroke="#dce2e7" stroke-width="1"/>
+<text x="346.9" y="516" font-size="15" fill="#566471" text-anchor="middle">5</text>
+<line x1="443.8" y1="88" x2="443.8" y2="492" stroke="#dce2e7" stroke-width="1"/>
+<text x="443.8" y="516" font-size="15" fill="#566471" text-anchor="middle">10</text>
+<line x1="540.6" y1="88" x2="540.6" y2="492" stroke="#dce2e7" stroke-width="1"/>
+<text x="540.6" y="516" font-size="15" fill="#566471" text-anchor="middle">15</text>
+<line x1="637.5" y1="88" x2="637.5" y2="492" stroke="#dce2e7" stroke-width="1"/>
+<text x="637.5" y="516" font-size="15" fill="#566471" text-anchor="middle">20</text>
+<line x1="734.4" y1="88" x2="734.4" y2="492" stroke="#dce2e7" stroke-width="1"/>
+<text x="734.4" y="516" font-size="15" fill="#566471" text-anchor="middle">25</text>
+<line x1="831.2" y1="88" x2="831.2" y2="492" stroke="#dce2e7" stroke-width="1"/>
+<text x="831.2" y="516" font-size="15" fill="#566471" text-anchor="middle">30</text>
 <text x="236" y="116.0" font-size="17" fill="#202b38" text-anchor="end">ChatGPT</text>
 <rect x="250" y="96" width="620.0" height="28" rx="4" fill="#20578c"/>
-<text x="880.0" y="116.0" font-size="16" fill="#202b38">28</text>
+<text x="880.0" y="116.0" font-size="16" fill="#202b38">32</text>
 <text x="236" y="160.0" font-size="17" fill="#202b38" text-anchor="end">DeepSeek</text>
-<rect x="250" y="140" width="310.0" height="28" rx="4" fill="#20578c"/>
-<text x="570.0" y="160.0" font-size="16" fill="#202b38">14</text>
+<rect x="250" y="140" width="329.4" height="28" rx="4" fill="#20578c"/>
+<text x="589.4" y="160.0" font-size="16" fill="#202b38">17</text>
 <text x="236" y="204.0" font-size="17" fill="#202b38" text-anchor="end">Doubao (豆包)</text>
-<rect x="250" y="184" width="110.7" height="28" rx="4" fill="#20578c"/>
-<text x="370.7" y="204.0" font-size="16" fill="#202b38">5</text>
-<text x="236" y="248.0" font-size="17" fill="#202b38" text-anchor="end">Gemini</text>
-<rect x="250" y="228" width="88.6" height="28" rx="4" fill="#20578c"/>
-<text x="348.6" y="248.0" font-size="16" fill="#202b38">4</text>
-<text x="236" y="292.0" font-size="17" fill="#202b38" text-anchor="end">Claude</text>
-<rect x="250" y="272" width="66.4" height="28" rx="4" fill="#20578c"/>
-<text x="326.4" y="292.0" font-size="16" fill="#202b38">3</text>
+<rect x="250" y="184" width="135.6" height="28" rx="4" fill="#20578c"/>
+<text x="395.6" y="204.0" font-size="16" fill="#202b38">7</text>
+<text x="236" y="248.0" font-size="17" fill="#202b38" text-anchor="end">Claude</text>
+<rect x="250" y="228" width="77.5" height="28" rx="4" fill="#20578c"/>
+<text x="337.5" y="248.0" font-size="16" fill="#202b38">4</text>
+<text x="236" y="292.0" font-size="17" fill="#202b38" text-anchor="end">Gemini</text>
+<rect x="250" y="272" width="77.5" height="28" rx="4" fill="#20578c"/>
+<text x="337.5" y="292.0" font-size="16" fill="#202b38">4</text>
 <text x="236" y="336.0" font-size="17" fill="#202b38" text-anchor="end">Kimi</text>
-<rect x="250" y="316" width="66.4" height="28" rx="4" fill="#20578c"/>
-<text x="326.4" y="336.0" font-size="16" fill="#202b38">3</text>
+<rect x="250" y="316" width="58.1" height="28" rx="4" fill="#20578c"/>
+<text x="318.1" y="336.0" font-size="16" fill="#202b38">3</text>
 <text x="236" y="380.0" font-size="17" fill="#202b38" text-anchor="end">Qwen (千问)</text>
-<rect x="250" y="360" width="22.1" height="28" rx="4" fill="#20578c"/>
-<text x="282.1" y="380.0" font-size="16" fill="#202b38">1</text>
+<rect x="250" y="360" width="19.4" height="28" rx="4" fill="#20578c"/>
+<text x="279.4" y="380.0" font-size="16" fill="#202b38">1</text>
 <text x="236" y="424.0" font-size="17" fill="#202b38" text-anchor="end">Zhipu Qingyan (智谱清言)</text>
-<rect x="250" y="404" width="22.1" height="28" rx="4" fill="#20578c"/>
-<text x="282.1" y="424.0" font-size="16" fill="#202b38">1</text>
+<rect x="250" y="404" width="19.4" height="28" rx="4" fill="#20578c"/>
+<text x="279.4" y="424.0" font-size="16" fill="#202b38">1</text>
 <text x="236" y="468.0" font-size="17" fill="#202b38" text-anchor="end">Tencent Yuanbao (腾讯元宝)</text>
 <text x="260.0" y="468.0" font-size="16" fill="#202b38">0</text>
 <text x="560.0" y="544" font-size="15" fill="#566471" text-anchor="middle">Students who selected the app (at most two selections each)</text>

--- a/tasks/PROGRESS.md
+++ b/tasks/PROGRESS.md
@@ -1,6 +1,6 @@
 # Progress board
 
-Generated on September 11, 2026 from the merged files in this repository.
+Generated on September 12, 2026 from the merged files in this repository.
 Click a username to see that student's merged pull requests.
 
 ![Bar chart of tasks passed per student](progress.svg)
@@ -20,27 +20,32 @@ Click a username to see that student's merged pull requests.
 | 11 | [harmonyhhh66](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Aharmonyhhh66) | 0 | — | 1 | 1 | 🥇 |
 | 12 | [huangz065](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ahuangz065) | 0 | — | 1 | 1 | 🥇 |
 | 13 | [huuob](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ahuuob) | 0 | — | 1 | 1 | 🥇 |
-| 14 | [jckinpku](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ajckinpku) | 0 | — | 1 | 1 | 🥇 |
-| 15 | [jdjxhll](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ajdjxhll) | 0 | — | 1 | 1 | 🥇 |
-| 16 | [licheng-mxj](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Alicheng-mxj) | 0 | — | 1 | 1 | 🥇 |
-| 17 | [liuyglucky](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Aliuyglucky) | 0 | — | 1 | 1 | 🥇 |
-| 18 | [lllusia](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Alllusia) | 0 | — | 1 | 1 | 🥇 |
-| 19 | [moonlightafar](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Amoonlightafar) | 0 | — | 1 | 1 | 🥇 |
-| 20 | [naonaozhong](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Anaonaozhong) | 0 | — | 1 | 1 | 🥇 |
-| 21 | [nashknight](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Anashknight) | 0 | — | 1 | 1 | 🥇 |
-| 22 | [s123y-s](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3As123y-s) | 0 | — | 1 | 1 | 🥇 |
-| 23 | [snowstalgia](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Asnowstalgia) | 0 | — | 1 | 1 | 🥇 |
-| 24 | [steven9912](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Asteven9912) | 0 | — | 1 | 1 | 🥇 |
-| 25 | [still-fantasy-star](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Astill-fantasy-star) | 0 | — | 1 | 1 | 🥇 |
-| 26 | [wangzj1020](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Awangzj1020) | 0 | — | 1 | 1 | 🥇 |
-| 27 | [wsqusaqi537](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Awsqusaqi537) | 0 | — | 1 | 1 | 🥇 |
-| 28 | [xpxpz](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Axpxpz) | 0 | — | 1 | 1 | 🥇 |
-| 29 | [yanghongpeng8-rgb](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ayanghongpeng8-rgb) | 0 | — | 1 | 1 | 🥇 |
-| 30 | [yannickchen77](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ayannickchen77) | 0 | — | 1 | 1 | 🥇 |
-| 31 | [yunlangli-shtj](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ayunlangli-shtj) | 0 | — | 1 | 1 | 🥇 |
-| 32 | [zhou-qixiang](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Azhou-qixiang) | 0 | — | 1 | 1 | 🥇 |
-| 33 | [zifangchu](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Azifangchu) | 0 | — | 1 | 1 | 🥇 |
-| 34 | [zyl-chou](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Azyl-chou) | 0 | — | 1 | 1 | 🥇 |
+| 14 | [ivanjfey](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Aivanjfey) | 0 | — | 1 | 1 | 🥇 |
+| 15 | [jckinpku](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ajckinpku) | 0 | — | 1 | 1 | 🥇 |
+| 16 | [jdjxhll](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ajdjxhll) | 0 | — | 1 | 1 | 🥇 |
+| 17 | [licheng-mxj](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Alicheng-mxj) | 0 | — | 1 | 1 | 🥇 |
+| 18 | [liuyglucky](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Aliuyglucky) | 0 | — | 1 | 1 | 🥇 |
+| 19 | [lllusia](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Alllusia) | 0 | — | 1 | 1 | 🥇 |
+| 20 | [mawenbin782-lgtm](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Amawenbin782-lgtm) | 0 | — | 1 | 1 | 🥇 |
+| 21 | [moonlightafar](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Amoonlightafar) | 0 | — | 1 | 1 | 🥇 |
+| 22 | [naonaozhong](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Anaonaozhong) | 0 | — | 1 | 1 | 🥇 |
+| 23 | [nashknight](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Anashknight) | 0 | — | 1 | 1 | 🥇 |
+| 24 | [rainybluenov](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Arainybluenov) | 0 | — | 1 | 1 | 🥇 |
+| 25 | [s123y-s](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3As123y-s) | 0 | — | 1 | 1 | 🥇 |
+| 26 | [saubazi-jie](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Asaubazi-jie) | 0 | — | 1 | 1 | 🥇 |
+| 27 | [snowstalgia](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Asnowstalgia) | 0 | — | 1 | 1 | 🥇 |
+| 28 | [steven9912](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Asteven9912) | 0 | — | 1 | 1 | 🥇 |
+| 29 | [still-fantasy-star](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Astill-fantasy-star) | 0 | — | 1 | 1 | 🥇 |
+| 30 | [wangzj1020](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Awangzj1020) | 0 | — | 1 | 1 | 🥇 |
+| 31 | [wsqusaqi537](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Awsqusaqi537) | 0 | — | 1 | 1 | 🥇 |
+| 32 | [xpxpz](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Axpxpz) | 0 | — | 1 | 1 | 🥇 |
+| 33 | [yanghongpeng8-rgb](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ayanghongpeng8-rgb) | 0 | — | 1 | 1 | 🥇 |
+| 34 | [yannickchen77](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ayannickchen77) | 0 | — | 1 | 1 | 🥇 |
+| 35 | [yunlangli-shtj](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Ayunlangli-shtj) | 0 | — | 1 | 1 | 🥇 |
+| 36 | [zhangbd-bot](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Azhangbd-bot) | 0 | — | 1 | 1 | 🥇 |
+| 37 | [zhou-qixiang](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Azhou-qixiang) | 0 | — | 1 | 1 | 🥇 |
+| 38 | [zifangchu](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Azifangchu) | 0 | — | 1 | 1 | 🥇 |
+| 39 | [zyl-chou](https://github.com/baojian/llm-26-fall/pulls?q=is%3Apr+is%3Amerged+author%3Azyl-chou) | 0 | — | 1 | 1 | 🥇 |
 
 **Columns.** *Tasks passed*: submissions whose checker passes. *Correct rate*:
 passed ÷ submitted. *Participation*: lectures with at least one submission,

--- a/tasks/progress.svg
+++ b/tasks/progress.svg
@@ -2,7 +2,7 @@
 <title id="t">Tasks passed per student</title>
 <rect width="960" height="994" fill="#fbfbf9"/>
 <text x="32" y="40" font-size="24" font-weight="700" fill="#202b38">Tasks passed per student</text>
-<text x="32" y="64" font-size="15" fill="#566471">34 students on the board · generated September 11, 2026</text>
+<text x="32" y="64" font-size="15" fill="#566471">39 students on the board · generated September 12, 2026</text>
 <line x1="220.0" y1="78" x2="220.0" y2="934" stroke="#dce2e7"/>
 <text x="220.0" y="954" font-size="13" fill="#566471" text-anchor="middle">0</text>
 <line x1="880.0" y1="78" x2="880.0" y2="934" stroke="#dce2e7"/>
@@ -33,28 +33,28 @@
 <text x="228.0" y="474.0" font-size="14" fill="#202b38">0</text>
 <text x="208" y="508.0" font-size="15" fill="#202b38" text-anchor="end">huuob</text>
 <text x="228.0" y="508.0" font-size="14" fill="#202b38">0</text>
-<text x="208" y="542.0" font-size="15" fill="#202b38" text-anchor="end">jckinpku</text>
+<text x="208" y="542.0" font-size="15" fill="#202b38" text-anchor="end">ivanjfey</text>
 <text x="228.0" y="542.0" font-size="14" fill="#202b38">0</text>
-<text x="208" y="576.0" font-size="15" fill="#202b38" text-anchor="end">jdjxhll</text>
+<text x="208" y="576.0" font-size="15" fill="#202b38" text-anchor="end">jckinpku</text>
 <text x="228.0" y="576.0" font-size="14" fill="#202b38">0</text>
-<text x="208" y="610.0" font-size="15" fill="#202b38" text-anchor="end">licheng-mxj</text>
+<text x="208" y="610.0" font-size="15" fill="#202b38" text-anchor="end">jdjxhll</text>
 <text x="228.0" y="610.0" font-size="14" fill="#202b38">0</text>
-<text x="208" y="644.0" font-size="15" fill="#202b38" text-anchor="end">liuyglucky</text>
+<text x="208" y="644.0" font-size="15" fill="#202b38" text-anchor="end">licheng-mxj</text>
 <text x="228.0" y="644.0" font-size="14" fill="#202b38">0</text>
-<text x="208" y="678.0" font-size="15" fill="#202b38" text-anchor="end">lllusia</text>
+<text x="208" y="678.0" font-size="15" fill="#202b38" text-anchor="end">liuyglucky</text>
 <text x="228.0" y="678.0" font-size="14" fill="#202b38">0</text>
-<text x="208" y="712.0" font-size="15" fill="#202b38" text-anchor="end">moonlightafar</text>
+<text x="208" y="712.0" font-size="15" fill="#202b38" text-anchor="end">lllusia</text>
 <text x="228.0" y="712.0" font-size="14" fill="#202b38">0</text>
-<text x="208" y="746.0" font-size="15" fill="#202b38" text-anchor="end">naonaozhong</text>
+<text x="208" y="746.0" font-size="15" fill="#202b38" text-anchor="end">mawenbin782-lgtm</text>
 <text x="228.0" y="746.0" font-size="14" fill="#202b38">0</text>
-<text x="208" y="780.0" font-size="15" fill="#202b38" text-anchor="end">nashknight</text>
+<text x="208" y="780.0" font-size="15" fill="#202b38" text-anchor="end">moonlightafar</text>
 <text x="228.0" y="780.0" font-size="14" fill="#202b38">0</text>
-<text x="208" y="814.0" font-size="15" fill="#202b38" text-anchor="end">s123y-s</text>
+<text x="208" y="814.0" font-size="15" fill="#202b38" text-anchor="end">naonaozhong</text>
 <text x="228.0" y="814.0" font-size="14" fill="#202b38">0</text>
-<text x="208" y="848.0" font-size="15" fill="#202b38" text-anchor="end">snowstalgia</text>
+<text x="208" y="848.0" font-size="15" fill="#202b38" text-anchor="end">nashknight</text>
 <text x="228.0" y="848.0" font-size="14" fill="#202b38">0</text>
-<text x="208" y="882.0" font-size="15" fill="#202b38" text-anchor="end">steven9912</text>
+<text x="208" y="882.0" font-size="15" fill="#202b38" text-anchor="end">rainybluenov</text>
 <text x="228.0" y="882.0" font-size="14" fill="#202b38">0</text>
-<text x="208" y="916.0" font-size="15" fill="#202b38" text-anchor="end">still-fantasy-star</text>
+<text x="208" y="916.0" font-size="15" fill="#202b38" text-anchor="end">s123y-s</text>
 <text x="228.0" y="916.0" font-size="14" fill="#202b38">0</text>
 </svg>


### PR DESCRIPTION
## Summary
- Re-tally `surveys/lecture-01` after merging #60, #61, #62, #63, #64: 37 counted responses (2 over-limit skipped), regenerated `results.svg` and the README results block.
- Rebuild `tasks/PROGRESS.md` and `tasks/progress.svg` (39 students).
- `scripts/survey_results.py`: accept checkboxes written as `[ x]` or `[x ]` (one response used that spacing and would otherwise count as zero selections).

## Validation
- `uv run python scripts/survey_results.py`: 37 responses counted, 2 skipped; counts changed only in the rows the five new responses selected.
- `uv run python scripts/progress.py`: 39 students.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jHi9BXDhwcYHotzqoCF4R
